### PR TITLE
feat: Add OpenAI/Codex usage tracking support

### DIFF
--- a/src/app/api/cron/sync-openai/route.ts
+++ b/src/app/api/cron/sync-openai/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
+import { runOpenAISync, getOpenAISyncState } from '@/lib/sync';
+
+/**
+ * OpenAI Cron Sync - runs daily at 7 AM UTC (staggered from Anthropic at 6 AM)
+ *
+ * Uses state tracking to efficiently sync only new data:
+ * - Tracks last synced date in sync_state table
+ * - Syncs from (last_synced_date - 1 day) to yesterday
+ * - Skips if already synced yesterday's data
+ *
+ * This endpoint is safe to call more frequently than daily -
+ * it will simply return early if there's no new data to sync.
+ */
+async function handler(request: Request) {
+  // Verify cron secret
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Check if provider is configured
+  if (!process.env.OPENAI_ADMIN_KEY) {
+    return NextResponse.json({
+      success: true,
+      service: 'openai',
+      skipped: true,
+      reason: 'OPENAI_ADMIN_KEY not configured'
+    });
+  }
+
+  // Get current sync state for logging
+  const stateBefore = await getOpenAISyncState();
+
+  const result = await runOpenAISync({ includeMappings: true });
+
+  // Check if we actually synced anything
+  const didSync = result.openai.syncedRange !== undefined;
+
+  return NextResponse.json({
+    success: result.openai.success,
+    service: 'openai',
+    didSync,
+    syncedRange: result.openai.syncedRange || null,
+    previousSyncState: stateBefore.lastSyncedDate,
+    result: {
+      openai: {
+        recordsImported: result.openai.recordsImported,
+        recordsSkipped: result.openai.recordsSkipped,
+        errors: result.openai.errors.slice(0, 5) // Limit errors in response
+      },
+      mappings: result.mappings ? {
+        mappingsCreated: result.mappings.mappingsCreated,
+        mappingsSkipped: result.mappings.mappingsSkipped
+      } : null
+    }
+  });
+}
+
+export const GET = wrapRouteHandlerWithSentry(handler, {
+  method: 'GET',
+  parameterizedRoute: '/api/cron/sync-openai',
+});
+
+export const POST = wrapRouteHandlerWithSentry(handler, {
+  method: 'POST',
+  parameterizedRoute: '/api/cron/sync-openai',
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -16,15 +16,29 @@ export { sql };
 // This allows gradual migration from raw SQL to Drizzle
 export { sql as vercelSql } from '@vercel/postgres';
 
-// Cost calculation for Claude models (per million tokens)
+// Cost calculation for models (per million tokens)
 // Cache write tokens cost 1.25x input price, cache read tokens cost 0.1x input price
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  // Claude models
   'claude-opus-4-5-20251101': { input: 15, output: 75 },
   'claude-opus-4-1-20250805': { input: 15, output: 75 },
   'claude-sonnet-4-5-20250929': { input: 3, output: 15 },
   'claude-sonnet-4-20250514': { input: 3, output: 15 },
   'claude-haiku-4-5-20251001': { input: 0.8, output: 4 },
   'claude-3-5-haiku-20241022': { input: 0.8, output: 4 },
+  // OpenAI GPT models
+  'gpt-4o': { input: 2.5, output: 10 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4-turbo': { input: 10, output: 30 },
+  'gpt-4': { input: 30, output: 60 },
+  'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
+  // OpenAI reasoning models
+  'o1': { input: 15, output: 60 },
+  'o1-mini': { input: 1.1, output: 4.4 },
+  'o1-pro': { input: 150, output: 600 },
+  'o3-mini': { input: 1.1, output: 4.4 },
+  // OpenAI Codex models
+  'codex-mini': { input: 1.5, output: 6 },
 };
 
 const CACHE_WRITE_MULTIPLIER = 1.25;

--- a/src/lib/sync/openai-mappings.ts
+++ b/src/lib/sync/openai-mappings.ts
@@ -1,0 +1,239 @@
+/**
+ * Auto-map OpenAI user IDs to user emails using the Admin API
+ *
+ * Uses the endpoint:
+ * - GET /v1/organization/users - Get all org users with emails
+ *
+ * OpenAI usage data includes user_id directly, so we just need to map user_id → email
+ */
+
+import { setToolIdentityMapping, getToolIdentityMappings, getUnmappedToolRecords } from '../queries';
+
+const TOOL = 'openai';
+
+interface OpenAIUser {
+  object: string;
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  added_at: number; // Unix timestamp
+}
+
+interface UsersResponse {
+  object: string;
+  data: OpenAIUser[];
+  has_more: boolean;
+  first_id?: string;
+  last_id?: string;
+}
+
+export interface MappingResult {
+  success: boolean;
+  mappingsCreated: number;
+  mappingsSkipped: number;
+  errors: string[];
+}
+
+async function fetchAllUsers(adminKey: string): Promise<Map<string, string>> {
+  const userMap = new Map<string, string>(); // user_id → email
+  let afterId: string | undefined;
+
+  do {
+    const params = new URLSearchParams({ limit: '100' });
+    if (afterId) params.set('after', afterId);
+
+    const response = await fetch(
+      `https://api.openai.com/v1/organization/users?${params}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${adminKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch users: ${response.status}`);
+    }
+
+    const data: UsersResponse = await response.json();
+
+    for (const user of data.data) {
+      userMap.set(user.id, user.email);
+    }
+
+    afterId = data.has_more ? data.last_id : undefined;
+  } while (afterId);
+
+  return userMap;
+}
+
+/**
+ * Sync all OpenAI user mappings (user_id → email)
+ */
+export async function syncOpenAIUserMappings(): Promise<MappingResult> {
+  const adminKey = process.env.OPENAI_ADMIN_KEY;
+  if (!adminKey) {
+    return {
+      success: false,
+      mappingsCreated: 0,
+      mappingsSkipped: 0,
+      errors: ['OPENAI_ADMIN_KEY not configured']
+    };
+  }
+
+  const result: MappingResult = {
+    success: true,
+    mappingsCreated: 0,
+    mappingsSkipped: 0,
+    errors: []
+  };
+
+  try {
+    // Fetch all users
+    const userMap = await fetchAllUsers(adminKey);
+
+    // Get existing mappings to avoid duplicates
+    const existingMappings = await getToolIdentityMappings(TOOL);
+    const existingSet = new Set(existingMappings.map(m => m.external_id));
+
+    // Create mappings for each user
+    for (const [userId, email] of userMap) {
+      // Skip if already mapped
+      if (existingSet.has(userId)) {
+        result.mappingsSkipped++;
+        continue;
+      }
+
+      try {
+        await setToolIdentityMapping(TOOL, userId, email);
+        result.mappingsCreated++;
+      } catch (err) {
+        result.errors.push(`Failed to save mapping for ${userId}: ${err}`);
+        result.mappingsSkipped++;
+      }
+    }
+
+  } catch (err) {
+    result.success = false;
+    result.errors.push(err instanceof Error ? err.message : 'Unknown error');
+  }
+
+  return result;
+}
+
+/**
+ * Get user email by user ID (for on-the-fly lookups)
+ */
+export async function getEmailForUserId(userId: string): Promise<string | null> {
+  const adminKey = process.env.OPENAI_ADMIN_KEY;
+  if (!adminKey) return null;
+
+  try {
+    const response = await fetch(
+      `https://api.openai.com/v1/organization/users/${userId}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${adminKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    if (!response.ok) return null;
+
+    const user: OpenAIUser = await response.json();
+    return user.email;
+
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Smart sync that uses incremental lookups for small numbers of unmapped users,
+ * falling back to full sync when there are many.
+ */
+export async function syncOpenAIUserMappingsSmart(
+  options: { incrementalThreshold?: number } = {}
+): Promise<MappingResult> {
+  const threshold = options.incrementalThreshold ?? 20;
+
+  // Check how many unmapped records we have for openai
+  const unmappedRecords = await getUnmappedToolRecords(TOOL);
+
+  if (unmappedRecords.length === 0) {
+    return {
+      success: true,
+      mappingsCreated: 0,
+      mappingsSkipped: 0,
+      errors: []
+    };
+  }
+
+  // If we have few unmapped users, do individual lookups (1 API call per user)
+  // If we have many, do full sync (1 paginated API call total)
+  if (unmappedRecords.length <= threshold) {
+    return syncOpenAIUserMappingsIncremental(unmappedRecords.map(r => r.tool_record_id));
+  }
+
+  return syncOpenAIUserMappings();
+}
+
+/**
+ * Incremental sync - looks up only specific user IDs individually.
+ * More efficient when only a few users need mapping.
+ */
+async function syncOpenAIUserMappingsIncremental(userIds: string[]): Promise<MappingResult> {
+  const adminKey = process.env.OPENAI_ADMIN_KEY;
+  if (!adminKey) {
+    return {
+      success: false,
+      mappingsCreated: 0,
+      mappingsSkipped: 0,
+      errors: ['OPENAI_ADMIN_KEY not configured']
+    };
+  }
+
+  const result: MappingResult = {
+    success: true,
+    mappingsCreated: 0,
+    mappingsSkipped: 0,
+    errors: []
+  };
+
+  for (const userId of userIds) {
+    try {
+      const response = await fetch(
+        `https://api.openai.com/v1/organization/users/${userId}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${adminKey}`,
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+
+      if (!response.ok) {
+        result.mappingsSkipped++;
+        if (response.status !== 404) {
+          result.errors.push(`Failed to fetch user ${userId}: ${response.status}`);
+        }
+        continue;
+      }
+
+      const user: OpenAIUser = await response.json();
+
+      // Save the mapping (also updates usage_records)
+      await setToolIdentityMapping(TOOL, userId, user.email);
+      result.mappingsCreated++;
+
+    } catch (err) {
+      result.mappingsSkipped++;
+      result.errors.push(`Error processing ${userId}: ${err instanceof Error ? err.message : 'Unknown'}`);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/sync/openai.ts
+++ b/src/lib/sync/openai.ts
@@ -1,0 +1,370 @@
+import { insertUsageRecord, getToolIdentityMappings } from '../queries';
+import { calculateCost } from '../db';
+import { normalizeModelName } from '../utils';
+import { sql } from '@vercel/postgres';
+
+interface OpenAIUsageResult {
+  input_tokens: number;
+  output_tokens: number;
+  input_cached_tokens: number;
+  num_model_requests: number;
+  project_id: string | null;
+  user_id: string | null;
+  api_key_id: string | null;
+  model: string | null;
+  batch: boolean;
+  service_tier: string | null;
+}
+
+interface OpenAITimeBucket {
+  start_time: number; // Unix timestamp in seconds
+  end_time: number;
+  results: OpenAIUsageResult[];
+}
+
+interface OpenAIUsageResponse {
+  object: string;
+  data: OpenAITimeBucket[];
+  has_more: boolean;
+  next_page?: string;
+}
+
+export interface SyncResult {
+  success: boolean;
+  recordsImported: number;
+  recordsSkipped: number;
+  errors: string[];
+  syncedRange?: { startDate: string; endDate: string };
+}
+
+const SYNC_STATE_ID = 'openai';
+
+// Get OpenAI sync state from database
+export async function getOpenAISyncState(): Promise<{ lastSyncedDate: string | null }> {
+  const result = await sql`
+    SELECT last_synced_hour_end FROM sync_state WHERE id = ${SYNC_STATE_ID}
+  `;
+  if (result.rows.length === 0 || !result.rows[0].last_synced_hour_end) {
+    return { lastSyncedDate: null };
+  }
+  return { lastSyncedDate: result.rows[0].last_synced_hour_end };
+}
+
+// Update OpenAI sync state
+async function updateOpenAISyncState(lastSyncedDate: string): Promise<void> {
+  await sql`
+    INSERT INTO sync_state (id, last_sync_at, last_synced_hour_end)
+    VALUES (${SYNC_STATE_ID}, NOW(), ${lastSyncedDate})
+    ON CONFLICT (id) DO UPDATE SET
+      last_sync_at = NOW(),
+      last_synced_hour_end = ${lastSyncedDate}
+  `;
+}
+
+// Get backfill state - derives oldest date from actual usage data
+export async function getOpenAIBackfillState(): Promise<{ oldestDate: string | null; isComplete: boolean }> {
+  const usageResult = await sql`
+    SELECT MIN(date)::text as oldest_date FROM usage_records WHERE tool = 'openai'
+  `;
+  const oldestDate = usageResult.rows[0]?.oldest_date || null;
+
+  const stateResult = await sql`
+    SELECT backfill_complete FROM sync_state WHERE id = ${SYNC_STATE_ID}
+  `;
+  const isComplete = stateResult.rows[0]?.backfill_complete === true;
+
+  return { oldestDate, isComplete };
+}
+
+// Mark backfill as complete
+async function markOpenAIBackfillComplete(): Promise<void> {
+  await sql`
+    INSERT INTO sync_state (id, last_sync_at, backfill_complete)
+    VALUES (${SYNC_STATE_ID}, NOW(), true)
+    ON CONFLICT (id) DO UPDATE SET
+      last_sync_at = NOW(),
+      backfill_complete = true
+  `;
+}
+
+// Reset backfill complete flag
+export async function resetOpenAIBackfillComplete(): Promise<void> {
+  await sql`
+    UPDATE sync_state SET backfill_complete = false WHERE id = ${SYNC_STATE_ID}
+  `;
+}
+
+/**
+ * Sync OpenAI usage for a specific date range.
+ * This is the low-level function that does the actual API fetching.
+ * Does NOT update sync state - use syncOpenAICron for production syncing.
+ */
+export async function syncOpenAIUsage(
+  startDate: string,
+  endDate: string,
+  options: { bucketWidth?: '1d' | '1h' | '1m' } = {}
+): Promise<SyncResult> {
+  const adminKey = process.env.OPENAI_ADMIN_KEY;
+  if (!adminKey) {
+    return {
+      success: false,
+      recordsImported: 0,
+      recordsSkipped: 0,
+      errors: ['OPENAI_ADMIN_KEY not configured']
+    };
+  }
+
+  const result: SyncResult = {
+    success: true,
+    recordsImported: 0,
+    recordsSkipped: 0,
+    errors: [],
+    syncedRange: { startDate, endDate }
+  };
+
+  // Get existing mappings for openai (user_id -> email)
+  const mappingsArray = await getToolIdentityMappings('openai');
+  const mappings = new Map<string, string>(
+    mappingsArray.map(m => [m.external_id, m.email])
+  );
+
+  const bucketWidth = options.bucketWidth || '1d';
+
+  // Convert dates to Unix timestamps (seconds)
+  const startTime = Math.floor(new Date(startDate).getTime() / 1000);
+  const endTime = Math.floor(new Date(endDate + 'T23:59:59Z').getTime() / 1000);
+
+  let page: string | undefined;
+
+  try {
+    do {
+      const params = new URLSearchParams({
+        start_time: startTime.toString(),
+        end_time: endTime.toString(),
+        bucket_width: bucketWidth,
+        'group_by[]': 'user_id',
+      });
+      params.append('group_by[]', 'model');
+
+      if (page) {
+        params.set('page', page);
+      }
+
+      const response = await fetch(
+        `https://api.openai.com/v1/organization/usage/completions?${params}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${adminKey}`,
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+
+      // On rate limit, immediately abort
+      if (response.status === 429) {
+        const errorText = await response.text();
+        result.success = false;
+        result.errors.push(`OpenAI API rate limited: ${errorText}`);
+        return result;
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`OpenAI API error: ${response.status} - ${errorText}`);
+      }
+
+      const data: OpenAIUsageResponse = await response.json();
+
+      for (const bucket of data.data) {
+        // Convert Unix timestamp to date string
+        const date = new Date(bucket.start_time * 1000).toISOString().split('T')[0];
+
+        for (const item of bucket.results) {
+          if (!item.model) continue;
+
+          // Resolve email from user_id mapping
+          let email = 'unknown';
+          const userId = item.user_id;
+
+          if (userId) {
+            email = mappings.get(userId) || 'unknown';
+          }
+
+          const inputTokens = item.input_tokens || 0;
+          const outputTokens = item.output_tokens || 0;
+          const cacheReadTokens = item.input_cached_tokens || 0;
+          // OpenAI doesn't have separate cache write tokens in usage API
+          const cacheWriteTokens = 0;
+
+          const cost = calculateCost(item.model, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens);
+
+          try {
+            await insertUsageRecord({
+              date,
+              email,
+              tool: 'openai',
+              model: normalizeModelName(item.model || 'unknown'),
+              inputTokens,
+              cacheWriteTokens,
+              cacheReadTokens,
+              outputTokens,
+              cost,
+              toolRecordId: userId || undefined
+            });
+            result.recordsImported++;
+          } catch (err) {
+            result.errors.push(`Insert error: ${err instanceof Error ? err.message : 'Unknown'}`);
+            result.recordsSkipped++;
+          }
+        }
+      }
+
+      page = data.has_more ? data.next_page : undefined;
+    } while (page);
+
+  } catch (err) {
+    result.success = false;
+    result.errors.push(err instanceof Error ? err.message : 'Unknown error');
+  }
+
+  return result;
+}
+
+/**
+ * Sync OpenAI usage for the cron job.
+ * Tracks state to avoid re-fetching data we already have.
+ * Syncs from (last_synced_date - 1 day) to yesterday.
+ */
+export async function syncOpenAICron(): Promise<SyncResult> {
+  const adminKey = process.env.OPENAI_ADMIN_KEY;
+  if (!adminKey) {
+    return {
+      success: false,
+      recordsImported: 0,
+      recordsSkipped: 0,
+      errors: ['OPENAI_ADMIN_KEY not configured']
+    };
+  }
+
+  // Get yesterday's date (complete day)
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+  // Check what we've already synced
+  const { lastSyncedDate } = await getOpenAISyncState();
+
+  // If we've already synced yesterday, nothing to do
+  if (lastSyncedDate && lastSyncedDate >= yesterdayStr) {
+    return {
+      success: true,
+      recordsImported: 0,
+      recordsSkipped: 0,
+      errors: [],
+      syncedRange: undefined
+    };
+  }
+
+  // Determine start date
+  let startDate: string;
+  if (!lastSyncedDate) {
+    const weekAgo = new Date();
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    startDate = weekAgo.toISOString().split('T')[0];
+  } else {
+    const lastDate = new Date(lastSyncedDate);
+    lastDate.setDate(lastDate.getDate() - 1);
+    startDate = lastDate.toISOString().split('T')[0];
+  }
+
+  const endDate = yesterdayStr;
+
+  const syncResult = await syncOpenAIUsage(startDate, endDate);
+
+  if (syncResult.success) {
+    await updateOpenAISyncState(yesterdayStr);
+  }
+
+  return syncResult;
+}
+
+/**
+ * Backfill OpenAI data for a date range.
+ * Works backwards from the oldest date we have data for.
+ */
+export async function backfillOpenAIUsage(
+  targetDate: string,
+  options: { onProgress?: (msg: string) => void; stopOnEmptyDays?: number } = {}
+): Promise<SyncResult & { rateLimited: boolean }> {
+  const log = options.onProgress || (() => {});
+  const stopOnEmptyDays = options.stopOnEmptyDays ?? 7;
+
+  const { oldestDate: existingOldest, isComplete } = await getOpenAIBackfillState();
+
+  if (isComplete) {
+    log(`Backfill already marked complete, skipping.`);
+    return {
+      success: true,
+      recordsImported: 0,
+      recordsSkipped: 0,
+      errors: [],
+      syncedRange: { startDate: targetDate, endDate: existingOldest || targetDate },
+      rateLimited: false
+    };
+  }
+
+  if (existingOldest && existingOldest <= targetDate) {
+    log(`Already have data back to ${existingOldest}, target is ${targetDate}. Done.`);
+    return {
+      success: true,
+      recordsImported: 0,
+      recordsSkipped: 0,
+      errors: [],
+      syncedRange: { startDate: targetDate, endDate: existingOldest },
+      rateLimited: false
+    };
+  }
+
+  let endDate: string;
+  if (existingOldest) {
+    const oldestDate = new Date(existingOldest);
+    oldestDate.setDate(oldestDate.getDate() - 1);
+    endDate = oldestDate.toISOString().split('T')[0];
+  } else {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    endDate = yesterday.toISOString().split('T')[0];
+  }
+
+  if (endDate < targetDate) {
+    endDate = targetDate;
+  }
+
+  log(`Fetching OpenAI usage from ${targetDate} to ${endDate}...`);
+  const syncResult = await syncOpenAIUsage(targetDate, endDate);
+
+  const rateLimited = syncResult.errors.some(e => e.includes('rate limited'));
+
+  if (rateLimited) {
+    log(`Rate limited! Will retry on next run.`);
+  } else if (syncResult.success) {
+    if (syncResult.recordsImported === 0) {
+      const startMs = new Date(targetDate).getTime();
+      const endMs = new Date(endDate).getTime();
+      const daysCovered = Math.ceil((endMs - startMs) / (24 * 60 * 60 * 1000));
+
+      log(`No records found for ${targetDate} to ${endDate} (${daysCovered} days).`);
+
+      if (daysCovered <= stopOnEmptyDays) {
+        log(`Small range (${daysCovered} days) with no data. Marking backfill complete.`);
+        await markOpenAIBackfillComplete();
+      } else {
+        log(`Large range - will continue backfilling on next run.`);
+      }
+    } else {
+      log(`Imported ${syncResult.recordsImported} records.`);
+    }
+  }
+
+  return { ...syncResult, rateLimited };
+}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -32,6 +32,12 @@ export const TOOL_CONFIGS: Record<string, ToolConfig> = {
     text: 'text-violet-400',
     gradient: 'from-violet-500/80 to-violet-400/60',
   },
+  openai: {
+    name: 'OpenAI',
+    bg: 'bg-green-500',
+    text: 'text-green-400',
+    gradient: 'from-green-500/80 to-green-400/60',
+  },
 };
 
 const DEFAULT_CONFIG: ToolConfig = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -174,6 +174,26 @@ export function normalizeModelName(model: string): string {
     normalized = `sonnet-${normalized}`;
   }
 
+  // OpenAI model normalization
+  // "gpt-4o-2024-08-06" → "gpt-4o"
+  // "gpt-4-turbo-2024-04-09" → "gpt-4-turbo"
+  // "gpt-3.5-turbo-0125" → "gpt-3.5-turbo"
+  if (normalized.startsWith('gpt-')) {
+    // Strip date suffixes (YYYY-MM-DD or MMDD format)
+    normalized = normalized.replace(/-\d{4}-\d{2}-\d{2}$/, '');
+    normalized = normalized.replace(/-\d{4}$/, '');
+  }
+
+  // "o1-2024-12-17" → "o1", "o1-mini-2024-09-12" → "o1-mini", "o3-mini-2025-01-31" → "o3-mini"
+  if (normalized.match(/^o[13]/)) {
+    normalized = normalized.replace(/-\d{4}-\d{2}-\d{2}$/, '');
+  }
+
+  // "codex-mini-latest" → "codex-mini"
+  if (normalized.startsWith('codex-')) {
+    normalized = normalized.replace(/-latest$/, '');
+  }
+
   // Reconstruct with suffix if present
   if (suffix) {
     normalized = `${normalized} (${suffix})`;
@@ -207,6 +227,20 @@ export function formatModelName(model: string): string {
       display = `${family.charAt(0).toUpperCase()}${family.slice(1)} ${version}${rest}`;
       break;
     }
+  }
+
+  // Format OpenAI models nicely
+  // "gpt-4o" → "GPT-4o", "gpt-3.5-turbo" → "GPT-3.5-turbo"
+  if (display.startsWith('gpt-')) {
+    display = 'GPT-' + display.slice(4);
+  }
+  // "o1-mini" → "O1-mini", "o3-mini" → "O3-mini"
+  if (display.match(/^o[13]/)) {
+    display = display.charAt(0).toUpperCase() + display.slice(1);
+  }
+  // "codex-mini" → "Codex-mini"
+  if (display.startsWith('codex-')) {
+    display = 'Codex-' + display.slice(6);
   }
 
   return display;


### PR DESCRIPTION
## Summary

Adds OpenAI API usage tracking following the existing provider pattern (Anthropic, Cursor). This integrates with OpenAI's Usage API to track token consumption across GPT-4o, o1, o3-mini, and Codex models.

**New files:**
- `src/lib/sync/openai.ts` - Main sync module with `syncOpenAIUsage()`, `syncOpenAICron()`, `backfillOpenAIUsage()`
- `src/lib/sync/openai-mappings.ts` - User ID to email mapping via `/v1/organization/users`
- `src/app/api/cron/sync-openai/route.ts` - Daily cron endpoint (7 AM UTC)

**Modified:**
- Added OpenAI tool config (green theme)
- Added OpenAI model pricing (GPT-4o, o1, o3-mini, codex-mini, etc.)
- Added OpenAI model name normalization
- Updated CLI with `openai:status`, `sync openai`, `backfill openai` commands
- Updated status endpoint to show OpenAI sync state

**Environment variable required:**
```
OPENAI_ADMIN_KEY=sk-admin-...
```
From: https://platform.openai.com/settings/organization/admin-keys

## ⚠️ Untested

This implementation has **not been tested** as Sentry does not currently have an OpenAI Enterprise plan with admin API access. The code follows the same patterns as the working Anthropic integration, but real-world testing is needed.

## ChatGPT Team Plan Limitations

During research, we discovered significant limitations for organizations on ChatGPT Team plans (vs Enterprise):

| Feature | Team | Enterprise |
|---------|------|------------|
| Usage API (`/v1/organization/usage/*`) | ❌ | ✅ |
| User Analytics dashboard | ❌ | ✅ |
| CSV export of usage | ❌ | ✅ |
| Compliance API | ❌ | ✅ |

**This means:** If your team uses Codex CLI authenticated via ChatGPT accounts (not API keys), usage tracking is **not available** on Team plans. Options:
1. Upgrade to Enterprise
2. Have team members use API keys instead of ChatGPT auth
3. Parse local Codex CLI logs (`~/.codex/sessions/`) - but this requires manual collection from each user

**Sources:**
- [User Analytics for ChatGPT Enterprise](https://help.openai.com/en/articles/10875114-user-analytics-for-chatgpt-enterprise-and-edu)
- [ChatGPT Team vs Enterprise comparison](https://thinkautomated.io/articles/chatgpt-enterprise-vs-team-our-2025-review)

## Test plan

- [ ] Set `OPENAI_ADMIN_KEY` environment variable
- [ ] Run `npm run cli openai:status` to verify connection
- [ ] Run `npm run cli sync openai --days 7` to sync recent data
- [ ] Verify data appears in dashboard with green "OpenAI" tool indicator
- [ ] Test backfill: `npm run cli backfill openai --from 2024-01-01 --to 2025-01-01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)