### PR TITLE
fix: Dismiss user panel when clicking View Full Details

### DIFF
--- a/src/components/UserDetailPanel.tsx
+++ b/src/components/UserDetailPanel.tsx
@@ -178,6 +178,7 @@ export function UserDetailPanel({ email, onClose }: UserDetailPanelProps) {
               <h2 className="font-display text-2xl text-white">{user?.email || displayEmail}</h2>
               <AppLink
                 href={`/users/${encodeURIComponent(username || '')}`}
+                onClick={onClose}
                 className="mt-3 inline-flex items-center gap-1.5 font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors"
               >
                 View Full Details


### PR DESCRIPTION
Previously when clicking on "View Full Details" in the user detail panel, the full details are loaded, but the panel stays in the open state. 

This obscures the actual full details:

<img width="1435" height="747" alt="image" src="https://github.com/user-attachments/assets/60a36e71-9dd1-4613-baba-de9e63f3921f" />

I think the panel should close?? This PR closes the panel to reveal the full user details.