### PR TITLE
fix: Add missing sync_state columns via migration

### DIFF
--- a/drizzle/0005_add_sync_state_columns.sql
+++ b/drizzle/0005_add_sync_state_columns.sql
@@ -1,0 +1,3 @@
+-- Add missing sync_state columns (schema defines them but no migration created them)
+ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS last_synced_hour_end VARCHAR(32);
+ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS backfill_oldest_date VARCHAR(10);


### PR DESCRIPTION
The schema defines `last_synced_hour_end` and `backfill_oldest_date` columns but no migration existed to create them, causing /status page to fail.

Before:

<img width="1366" height="390" alt="image" src="https://github.com/user-attachments/assets/6be7afc1-8cde-4525-b189-18caa8e14775" />

After:

<img width="1289" height="622" alt="image" src="https://github.com/user-attachments/assets/e6404f26-1df2-45eb-b06f-24b0e02369a8" />


