### PR TITLE
fix(nav): Add responsive hamburger menu for mobile navigation

### DIFF
--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -28,7 +28,7 @@ const navItems: NavItem[] = [
 export function MainNav({ days }: MainNavProps) {
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLElement>(null);
 
   // Close menu when clicking outside
   useEffect(() => {


### PR DESCRIPTION
On mobile devices, the horizontal navigation overflowed the screen width.
This adds a hamburger menu that:
- Shows on mobile (<640px) with a dropdown menu
- Maintains the existing desktop layout unchanged
- Closes on click outside, escape key, or route change
- Indicates the active page with a cyan dot