### PR TITLE
fix(header): Make header single-row on mobile by hiding search

### DIFF
--- a/src/app/adoption/page.tsx
+++ b/src/app/adoption/page.tsx
@@ -148,7 +148,7 @@ function AdoptionPageContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
             <UserMenu />
           </div>

--- a/src/app/commits/page.tsx
+++ b/src/app/commits/page.tsx
@@ -194,14 +194,16 @@ function CommitsPageContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
             <div className="flex items-center gap-3">
-              <InlineSearchInput
-                value={searchQuery}
-                onChange={setSearchQuery}
-                placeholder="Filter repositories..."
-              />
+              <div className="hidden sm:block">
+                <InlineSearchInput
+                  value={searchQuery}
+                  onChange={setSearchQuery}
+                  placeholder="Filter repositories..."
+                />
+              </div>
               <UserMenu />
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -192,10 +192,12 @@ function DashboardContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
             <div className="flex items-center gap-3">
-              <SearchInput days={days} placeholder="Search users..." />
+              <div className="hidden sm:block">
+                <SearchInput days={days} placeholder="Search users..." />
+              </div>
               <UserMenu />
             </div>
           </div>

--- a/src/app/tips/[slug]/page.tsx
+++ b/src/app/tips/[slug]/page.tsx
@@ -44,7 +44,7 @@ function GuideContent() {
         {/* Header */}
         <header className="relative z-20 border-b border-white/5">
           <PageContainer className="py-4">
-            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div className="flex items-center justify-between gap-4">
               <MainNav days={days} />
               <UserMenu />
             </div>
@@ -78,7 +78,7 @@ function GuideContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
             <UserMenu />
           </div>

--- a/src/app/tips/page.tsx
+++ b/src/app/tips/page.tsx
@@ -72,7 +72,7 @@ function TipsIndexContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
             <UserMenu />
           </div>

--- a/src/app/users/[email]/page.tsx
+++ b/src/app/users/[email]/page.tsx
@@ -244,11 +244,9 @@ function UserDetailContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
-            <div className="flex items-center gap-3">
-              <UserMenu />
-            </div>
+            <UserMenu />
           </div>
         </PageContainer>
       </header>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -167,14 +167,16 @@ function UsersPageContent() {
       {/* Header */}
       <header className="relative z-20 border-b border-white/5">
         <PageContainer className="py-4">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
             <div className="flex items-center gap-3">
-              <InlineSearchInput
-                value={searchQuery}
-                onChange={setSearchQuery}
-                placeholder="Filter users..."
-              />
+              <div className="hidden sm:block">
+                <InlineSearchInput
+                  value={searchQuery}
+                  onChange={setSearchQuery}
+                  placeholder="Filter users..."
+                />
+              </div>
               <UserMenu />
             </div>
           </div>


### PR DESCRIPTION
- Changed header layout from flex-col on mobile to always flex-row
- Hide search input on mobile viewports (shown on sm and up)
- Users can still search via the Users page on mobile
- Keeps header compact and consistent across all pages