### PR TITLE
fix(mobile): Move hamburger menu to right of profile

### DIFF
--- a/src/app/adoption/page.tsx
+++ b/src/app/adoption/page.tsx
@@ -7,6 +7,7 @@ import { Compass, Flame, Zap, Star, Users, TrendingUp, Target } from 'lucide-rea
 import { StatCard } from '@/components/StatCard';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { TimeRangeSelector } from '@/components/TimeRangeSelector';
 import { AdoptionFunnel } from '@/components/AdoptionFunnel';
 import { AdoptionBadge } from '@/components/AdoptionBadge';
@@ -150,7 +151,10 @@ function AdoptionPageContent() {
         <PageContainer className="py-4">
           <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
-            <UserMenu />
+            <div className="flex items-center gap-3">
+              <UserMenu />
+              <MobileNav days={days} />
+            </div>
           </div>
         </PageContainer>
       </header>

--- a/src/app/commits/page.tsx
+++ b/src/app/commits/page.tsx
@@ -8,6 +8,7 @@ import { InlineSearchInput } from '@/components/SearchInput';
 import { TimeRangeSelector } from '@/components/TimeRangeSelector';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { TipBar } from '@/components/TipBar';
 import { PageContainer } from '@/components/PageContainer';
 import { useTimeRange } from '@/contexts/TimeRangeContext';
@@ -205,6 +206,7 @@ function CommitsPageContent() {
                 />
               </div>
               <UserMenu />
+              <MobileNav days={days} />
             </div>
           </div>
         </PageContainer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { SearchInput } from '@/components/SearchInput';
 import { TipBar } from '@/components/TipBar';
 import { TimeRangeSelector } from '@/components/TimeRangeSelector';
 import { MainNav } from '@/components/MainNav';
+import { MobileNav } from '@/components/MobileNav';
 import { UserMenu } from '@/components/UserMenu';
 import { LifetimeStats } from '@/components/LifetimeStats';
 import { AdoptionDistribution } from '@/components/AdoptionDistribution';
@@ -199,6 +200,7 @@ function DashboardContent() {
                 <SearchInput days={days} placeholder="Search users..." />
               </div>
               <UserMenu />
+              <MobileNav days={days} />
             </div>
           </div>
         </PageContainer>

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { PageContainer } from '@/components/PageContainer';
 import { DEFAULT_DAYS } from '@/lib/constants';
 import { formatTokens, formatCurrency } from '@/lib/utils';
@@ -170,7 +171,10 @@ export default function StatusPage() {
         <PageContainer className="py-4">
           <div className="flex items-center justify-between">
             <MainNav days={DEFAULT_DAYS} />
-            <UserMenu />
+            <div className="flex items-center gap-3">
+              <UserMenu />
+              <MobileNav days={DEFAULT_DAYS} />
+            </div>
           </div>
         </PageContainer>
       </header>

--- a/src/app/tips/[slug]/page.tsx
+++ b/src/app/tips/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { ExternalLink, Compass, RefreshCw, Command, MapPin, Cpu, MessageSquare, 
 import { AppLink } from '@/components/AppLink';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { TipBar } from '@/components/TipBar';
 import { PageContainer } from '@/components/PageContainer';
 import { useTimeRange } from '@/contexts/TimeRangeContext';
@@ -46,7 +47,10 @@ function GuideContent() {
           <PageContainer className="py-4">
             <div className="flex items-center justify-between gap-4">
               <MainNav days={days} />
-              <UserMenu />
+              <div className="flex items-center gap-3">
+                <UserMenu />
+                <MobileNav days={days} />
+              </div>
             </div>
           </PageContainer>
         </header>

--- a/src/app/tips/page.tsx
+++ b/src/app/tips/page.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, Compass, RefreshCw, Command, MapPin, Cpu, MessageSquare, Gi
 import { AppLink } from '@/components/AppLink';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { TipBar } from '@/components/TipBar';
 import { PageContainer } from '@/components/PageContainer';
 import { useTimeRange } from '@/contexts/TimeRangeContext';
@@ -74,7 +75,10 @@ function TipsIndexContent() {
         <PageContainer className="py-4">
           <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
-            <UserMenu />
+            <div className="flex items-center gap-3">
+              <UserMenu />
+              <MobileNav days={days} />
+            </div>
           </div>
         </PageContainer>
       </header>

--- a/src/app/users/[email]/page.tsx
+++ b/src/app/users/[email]/page.tsx
@@ -9,6 +9,7 @@ import { StackedBarChart } from '@/components/StackedBarChart';
 import { TimeRangeSelector } from '@/components/TimeRangeSelector';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { UserProfileHeader } from '@/components/UserProfileHeader';
 import { AdoptionBadge } from '@/components/AdoptionBadge';
 import { TipBar } from '@/components/TipBar';
@@ -246,7 +247,10 @@ function UserDetailContent() {
         <PageContainer className="py-4">
           <div className="flex items-center justify-between gap-4">
             <MainNav days={days} />
-            <UserMenu />
+            <div className="flex items-center gap-3">
+              <UserMenu />
+              <MobileNav days={days} />
+            </div>
           </div>
         </PageContainer>
       </header>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -7,6 +7,7 @@ import { InlineSearchInput } from '@/components/SearchInput';
 import { TimeRangeSelector } from '@/components/TimeRangeSelector';
 import { MainNav } from '@/components/MainNav';
 import { UserMenu } from '@/components/UserMenu';
+import { MobileNav } from '@/components/MobileNav';
 import { AdoptionBadge } from '@/components/AdoptionBadge';
 import { UserLink } from '@/components/UserLink';
 import { TipBar } from '@/components/TipBar';
@@ -178,6 +179,7 @@ function UsersPageContent() {
                 />
               </div>
               <UserMenu />
+              <MobileNav days={days} />
             </div>
           </div>
         </PageContainer>

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Menu, X } from 'lucide-react';
 import { AbacusLogo } from '@/components/AbacusLogo';
 
 interface NavItem {
@@ -28,41 +26,6 @@ const navItems: NavItem[] = [
 
 export function MainNav({ days }: MainNavProps) {
   const pathname = usePathname();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLElement>(null);
-
-  // Close menu when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setMobileMenuOpen(false);
-      }
-    }
-
-    if (mobileMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-    }
-  }, [mobileMenuOpen]);
-
-  // Close menu on escape
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setMobileMenuOpen(false);
-      }
-    }
-
-    if (mobileMenuOpen) {
-      document.addEventListener('keydown', handleEscape);
-      return () => document.removeEventListener('keydown', handleEscape);
-    }
-  }, [mobileMenuOpen]);
-
-  // Close menu on route change
-  useEffect(() => {
-    setMobileMenuOpen(false);
-  }, [pathname]);
 
   const isActive = (item: NavItem) => {
     if (item.href === '/') {
@@ -80,7 +43,7 @@ export function MainNav({ days }: MainNavProps) {
   };
 
   return (
-    <nav className="flex items-center gap-4 sm:gap-8" ref={menuRef}>
+    <nav className="flex items-center gap-4 sm:gap-8">
       {/* App Title */}
       <Link href={`/?days=${days}`} className="flex items-center gap-2.5 group">
         <AbacusLogo className="w-6 h-6 text-white/80 transition-all duration-200 group-hover:text-white group-hover:scale-105" />
@@ -88,56 +51,6 @@ export function MainNav({ days }: MainNavProps) {
           Abacus
         </span>
       </Link>
-
-      {/* Mobile Menu Button */}
-      <div className="sm:hidden relative">
-        <button
-          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-          className="flex items-center justify-center w-8 h-8 rounded-md text-white/60 hover:text-white hover:bg-white/10 transition-colors"
-          aria-expanded={mobileMenuOpen}
-          aria-label="Toggle navigation menu"
-        >
-          {mobileMenuOpen ? (
-            <X className="w-5 h-5" />
-          ) : (
-            <Menu className="w-5 h-5" />
-          )}
-        </button>
-
-        {/* Mobile Dropdown Menu */}
-        {mobileMenuOpen && (
-          <div
-            className="absolute left-0 top-full mt-2 w-48 origin-top-left rounded-lg border border-white/10 bg-[#0a0a0f]/95 backdrop-blur-sm shadow-xl shadow-black/20 z-50"
-            style={{
-              animation: 'slideUp 0.15s ease-out',
-            }}
-          >
-            <div className="py-1">
-              {navItems.map((item) => {
-                const active = isActive(item);
-                return (
-                  <Link
-                    key={item.href}
-                    href={getHref(item)}
-                    className={`flex items-center gap-3 px-4 py-2.5 transition-colors ${
-                      active
-                        ? 'text-white bg-white/5'
-                        : 'text-white/60 hover:text-white hover:bg-white/5'
-                    }`}
-                  >
-                    <span className="font-mono text-xs uppercase tracking-wider">
-                      {item.label}
-                    </span>
-                    {active && (
-                      <div className="ml-auto w-1.5 h-1.5 rounded-full bg-cyan-500" />
-                    )}
-                  </Link>
-                );
-              })}
-            </div>
-          </div>
-        )}
-      </div>
 
       {/* Desktop Divider */}
       <div className="hidden sm:block h-4 w-px bg-white/10" />

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Menu, X } from 'lucide-react';
+
+interface NavItem {
+  label: string;
+  href: string;
+  matchPaths: string[];
+}
+
+interface MobileNavProps {
+  days: number;
+}
+
+const navItems: NavItem[] = [
+  { label: 'Overview', href: '/', matchPaths: ['/'] },
+  { label: 'Users', href: '/users', matchPaths: ['/users'] },
+  { label: 'Commits', href: '/commits', matchPaths: ['/commits'] },
+  { label: 'Adoption', href: '/adoption', matchPaths: ['/adoption'] },
+  { label: 'Tips', href: '/tips', matchPaths: ['/tips'] },
+  { label: 'Status', href: '/status', matchPaths: ['/status'] },
+];
+
+export function MobileNav({ days }: MobileNavProps) {
+  const pathname = usePathname();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMobileMenuOpen(false);
+      }
+    }
+
+    if (mobileMenuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [mobileMenuOpen]);
+
+  // Close menu on escape
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setMobileMenuOpen(false);
+      }
+    }
+
+    if (mobileMenuOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [mobileMenuOpen]);
+
+  // Close menu on route change
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [pathname]);
+
+  const isActive = (item: NavItem) => {
+    if (item.href === '/') {
+      return pathname === '/';
+    }
+    return item.matchPaths.some(path => pathname.startsWith(path));
+  };
+
+  const getHref = (item: NavItem) => {
+    // Preserve days param for routes that use it (not tips or status)
+    if (item.href === '/' || item.href === '/users' || item.href === '/commits' || item.href === '/adoption') {
+      return `${item.href}?days=${days}`;
+    }
+    return item.href;
+  };
+
+  return (
+    <div className="sm:hidden relative" ref={menuRef}>
+      <button
+        onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+        className="flex items-center justify-center w-8 h-8 rounded-md text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+        aria-expanded={mobileMenuOpen}
+        aria-label="Toggle navigation menu"
+      >
+        {mobileMenuOpen ? (
+          <X className="w-5 h-5" />
+        ) : (
+          <Menu className="w-5 h-5" />
+        )}
+      </button>
+
+      {/* Mobile Dropdown Menu */}
+      {mobileMenuOpen && (
+        <div
+          className="absolute right-0 top-full mt-2 w-48 origin-top-right rounded-lg border border-white/10 bg-[#0a0a0f]/95 backdrop-blur-sm shadow-xl shadow-black/20 z-50"
+          style={{
+            animation: 'slideUp 0.15s ease-out',
+          }}
+        >
+          <div className="py-1">
+            {navItems.map((item) => {
+              const active = isActive(item);
+              return (
+                <Link
+                  key={item.href}
+                  href={getHref(item)}
+                  className={`flex items-center gap-3 px-4 py-2.5 transition-colors ${
+                    active
+                      ? 'text-white bg-white/5'
+                      : 'text-white/60 hover:text-white hover:bg-white/5'
+                  }`}
+                >
+                  <span className="font-mono text-xs uppercase tracking-wider">
+                    {item.label}
+                  </span>
+                  {active && (
+                    <div className="ml-auto w-1.5 h-1.5 rounded-full bg-cyan-500" />
+                  )}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The hamburger menu was positioned incorrectly next to the logo on mobile.
This moves it to the right side of the header, after the profile menu,
for a more intuitive mobile layout.