### PR TITLE
feat(commits): Support multiple AI tool attributions per commit

### DIFF
--- a/drizzle/0008_multi_tool_attribution.sql
+++ b/drizzle/0008_multi_tool_attribution.sql
@@ -1,0 +1,27 @@
+-- Multi-tool commit attribution support
+-- Allows a single commit to be attributed to multiple AI tools
+
+-- Add message column for retroactive attribution fixes
+ALTER TABLE commits ADD COLUMN IF NOT EXISTS message TEXT;
+
+-- Create junction table for multiple tool attributions per commit
+CREATE TABLE IF NOT EXISTS commit_attributions (
+  id SERIAL PRIMARY KEY,
+  commit_id INTEGER NOT NULL REFERENCES commits(id) ON DELETE CASCADE,
+  ai_tool VARCHAR(64) NOT NULL,
+  ai_model VARCHAR(128),
+  confidence VARCHAR(20) DEFAULT 'detected',
+  source VARCHAR(64),
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(commit_id, ai_tool)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commit_attributions_commit ON commit_attributions(commit_id);
+CREATE INDEX IF NOT EXISTS idx_commit_attributions_tool ON commit_attributions(ai_tool);
+
+-- Migrate existing attribution data to junction table
+INSERT INTO commit_attributions (commit_id, ai_tool, ai_model, confidence, source)
+SELECT id, ai_tool, ai_model, 'detected', 'legacy_migration'
+FROM commits
+WHERE ai_tool IS NOT NULL
+ON CONFLICT (commit_id, ai_tool) DO NOTHING;


### PR DESCRIPTION
Support multiple AI tool attributions per commit

Previously, each commit could only be attributed to a single AI tool. This was
limiting because a single commit can reasonably involve multiple tools:
- Co-authored commits with multiple AI assistants
- Mixed assistance (one tool for initial code, another for refactoring)
- Commit messages mentioning multiple tools

This PR adds a junction table `commit_attributions` to track multiple AI tools
per commit, while keeping the existing `ai_tool` column on commits as a
denormalized field for backward compatibility.

**Schema changes:**
- New `commit_attributions` table with commit_id, ai_tool, ai_model, confidence, source
- Added `message` column to commits table for retroactive attribution fixes

**Detection changes:**
- `detectAllAiAttributions()` now returns ALL matching tools instead of stopping at first match
- Each attribution includes the source (co_author, message_pattern, author_field)

**Query changes:**
- `getRepositoryCommits()` now fetches attributions from junction table
- UI displays multiple tool badges when a commit has multiple attributions

The migration includes automatic data migration from existing `commits.ai_tool`
values to the new junction table.