### PR TITLE
fix(github): Auto-sync email mappings after commit sync

### DIFF
--- a/src/app/api/cron/sync-github-mappings/route.ts
+++ b/src/app/api/cron/sync-github-mappings/route.ts
@@ -19,13 +19,15 @@ async function handler(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Check if GitHub is configured
-  if (!process.env.GITHUB_APP_ID || !process.env.GITHUB_PRIVATE_KEY) {
+  // Check if GitHub is configured (either App or personal token)
+  const hasGitHubApp = process.env.GITHUB_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY && process.env.GITHUB_APP_INSTALLATION_ID;
+  const hasGitHubToken = process.env.GITHUB_TOKEN;
+  if (!hasGitHubApp && !hasGitHubToken) {
     return NextResponse.json({
       success: true,
       service: 'github-mappings',
       skipped: true,
-      reason: 'GitHub App not configured'
+      reason: 'GitHub not configured (set GITHUB_APP_* or GITHUB_TOKEN)'
     });
   }
 

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -108,7 +108,7 @@ async function handler() {
   }
 
   // GitHub
-  const githubConfigured = !!(process.env.GITHUB_APP_ID && process.env.GITHUB_PRIVATE_KEY) || !!process.env.GITHUB_TOKEN;
+  const githubConfigured = !!(process.env.GITHUB_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY && process.env.GITHUB_APP_INSTALLATION_ID) || !!process.env.GITHUB_TOKEN;
   if (githubConfigured) {
     const [githubSync, githubBackfill] = await Promise.all([
       getGitHubSyncState(),


### PR DESCRIPTION
- Fix wrong env var check in cron job (GITHUB_PRIVATE_KEY → GITHUB_APP_PRIVATE_KEY)
- Add intelligent email mapping sync to CLI github:sync command
- Automatically sync email mappings when unattributed commits exist
- Skip mapping sync if rate limited to avoid hitting API limits

This ensures users with noreply GitHub emails get properly mapped
without requiring a separate manual `github:users:sync` command.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>