### PR TITLE
fix(auth): Center sign-in page content properly with footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="antialiased noise-overlay min-h-screen flex flex-col bg-[#050507]">
         <Providers>
-          <div className="flex-1">
+          <div className="flex-1 flex flex-col">
             {children}
           </div>
           <Footer />

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -74,7 +74,7 @@ function SignInContent() {
   }, [callbackUrl]);
 
   return (
-    <div className="min-h-screen bg-[#050507] text-white grid-bg flex items-center justify-center p-4">
+    <div className="flex-1 bg-[#050507] text-white grid-bg flex items-center justify-center p-4">
       {/* Subtle ambient glow */}
       <div
         className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] pointer-events-none opacity-[0.03]"
@@ -169,7 +169,7 @@ export default function SignInPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-[#050507] grid-bg flex items-center justify-center">
+        <div className="flex-1 bg-[#050507] grid-bg flex items-center justify-center">
           <div className="font-mono text-white/40 text-sm">Loading...</div>
         </div>
       }


### PR DESCRIPTION
The sign-in page was not vertically centered because it used
min-h-screen (100vh) which didn't account for the footer height.

Changes:
- Add flex flex-col to root layout wrapper to propagate flex context
- Replace min-h-screen with flex-1 on sign-in page so it fills
  remaining space after footer
- This makes the sign-in content center within the actual available
  viewport space, responsive on mobile and desktop

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>