### PR TITLE
fix: Add missing sync_state columns via migration

### DIFF
--- a/drizzle/0010_add_sync_state_columns.sql
+++ b/drizzle/0010_add_sync_state_columns.sql
@@ -1,0 +1,14 @@
+-- Add missing sync_state columns for incremental sync tracking
+-- These columns were defined in schema.ts but never added via migration
+
+-- last_synced_hour_end: Used by Cursor (epoch ms) and reused by Anthropic/GitHub (ISO date string)
+ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS last_synced_hour_end VARCHAR(32);
+
+-- backfill_oldest_date: Tracks the oldest date successfully synced during backfill
+ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS backfill_oldest_date VARCHAR(10);
+
+-- backfill_complete: Already handled by migration 0004, but add IF NOT EXISTS as safety
+ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS backfill_complete BOOLEAN DEFAULT FALSE;
+
+-- Convert last_cursor to varchar if it's still text (consistency with schema)
+ALTER TABLE sync_state ALTER COLUMN last_cursor TYPE VARCHAR(255);


### PR DESCRIPTION
Add missing sync_state columns that were defined in schema.ts but never
created via migration, causing the /status page to fail when querying
sync state.

The schema expected `last_synced_hour_end`, `backfill_oldest_date`, and
`backfill_complete` columns, but only `id`, `last_sync_at`, and `last_cursor`
were created in the initial migration.

Additionally fixes migration 0004 which assumed `backfill_complete` existed
as text and tried to convert it to boolean - but the column was never created.
The fix uses a DO block to gracefully handle all cases (column missing, 
column as text, column as boolean).

Closes #6

Co-Authored-By: Derek Haynes <derek@dlite.cc>