### PR TITLE
fix(db): Sync Drizzle journal and add migration workflow skill

### DIFF
--- a/.claude/skills/db-migrate/SKILL.md
+++ b/.claude/skills/db-migrate/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: db-migrate
+description: Create database migrations using Drizzle Kit. Use when adding/modifying tables, columns, or indexes. Ensures schema.ts and migrations stay in sync.
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+# Database Migration Skill
+
+Create schema changes with proper migrations.
+
+## Before Starting
+
+1. Read current schema: `src/lib/schema.ts`
+2. Read recent migrations: `drizzle/*.sql` (last 2-3)
+3. Understand current state before making changes
+
+## Workflow
+
+### Step 1: Modify Schema First
+
+Edit `src/lib/schema.ts` with your changes:
+- Add new tables with `pgTable()`
+- Add columns to existing tables
+- Add/modify indexes
+
+### Step 2: Generate Migration
+
+Run Drizzle Kit to generate migration SQL:
+```bash
+pnpm drizzle-kit generate
+```
+
+This creates a new file in `drizzle/` like `0011_descriptive_name.sql`.
+
+### Step 3: Review Generated Migration
+
+Read the generated migration and verify:
+- [ ] SQL looks correct
+- [ ] No destructive changes (DROP without intent)
+- [ ] Index names follow convention
+- [ ] Column types match schema.ts
+
+### Step 4: Test Locally (Optional - Be Careful!)
+
+**WARNING**: Only test migrations locally if `POSTGRES_URL` points to a LOCAL database.
+If it points to production, skip this step - migrations will run automatically on Vercel deploy.
+
+To check your database URL:
+```bash
+echo $POSTGRES_URL  # Should be localhost or local container
+```
+
+If local database is configured:
+```bash
+pnpm build  # Runs migrations automatically
+pnpm cli stats  # Verify queries work
+```
+
+### Step 5: Verify in PR
+
+- [ ] Migration SQL looks correct (review diff)
+- [ ] schema.ts and migration are in same commit
+- [ ] No `IF NOT EXISTS` clauses (signals potential drift)
+
+## Common Patterns
+
+### Adding a Column
+```typescript
+// schema.ts
+export const myTable = pgTable('my_table', {
+  // existing columns...
+  newColumn: varchar('new_column', { length: 255 }),
+});
+```
+
+### Adding an Index
+```typescript
+export const myTable = pgTable('my_table', {
+  // columns...
+}, (table) => [
+  index('idx_my_table_column').on(table.column),
+]);
+```
+
+### Adding a Table
+```typescript
+export const newTable = pgTable('new_table', {
+  id: serial('id').primaryKey(),
+  // columns...
+}, (table) => [
+  // indexes...
+]);
+```
+
+## Anti-Patterns (Don't Do This)
+
+- Editing schema.ts without running `drizzle-kit generate`
+- Writing migration SQL by hand (use generate)
+- Modifying existing migrations after they've been applied to prod
+- Using `IF NOT EXISTS` in new migrations (signals drift)
+
+## Checklist
+
+Before committing:
+- [ ] schema.ts changes match generated migration
+- [ ] Migration tested locally with `pnpm build` (only if local DB configured)
+- [ ] No `IF NOT EXISTS` clauses (clean migration)
+- [ ] Both schema.ts and migration in same commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,15 @@ Use `<AppLink>` for internal links (preserves `?days=N`). Use `useTimeRange()` h
 
 Migrations in `/drizzle/` run automatically on `pnpm build`. Manual: `pnpm cli db:migrate`
 
+### Schema Changes
+
+Use `db-migrate` skill when modifying database schema. Key rules:
+- NEVER edit `src/lib/schema.ts` without generating a corresponding migration
+- Use `pnpm drizzle-kit generate` to create migrations from schema changes
+- Both schema.ts and migration must be in the same commit
+
+See `.claude/skills/db-migrate/SKILL.md` for the full workflow.
+
 ## CLI
 
 ```bash

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,69 @@
       "when": 1736216400000,
       "tag": "0001_normalize_model_names",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1736300400000,
+      "tag": "0002_add_better_auth_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1736300500000,
+      "tag": "0003_modular_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1736300600000,
+      "tag": "0004_schema_improvements",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1736300700000,
+      "tag": "0005_make_email_nullable",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1736300800000,
+      "tag": "0006_add_commits_tracking",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1736300900000,
+      "tag": "0007_unify_identity_mappings",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1736301000000,
+      "tag": "0008_multi_tool_attribution",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1736301100000,
+      "tag": "0009_normalize_copilot_tool_name",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1736301200000,
+      "tag": "0010_add_sync_state_columns",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Sync the Drizzle Kit journal with all existing migrations and add workflow
guidance to prevent future schema drift issues.

## Problem

PR #19 revealed that columns were being added to `schema.ts` without
corresponding migrations, causing runtime errors when the code tried to
query non-existent columns. The `_journal.json` only tracked 2 of 11
migrations, making `drizzle-kit` commands unreliable.

## Solution

1. **Updated `drizzle/meta/_journal.json`** - Added entries for all 11
   migrations (0000-0010) so Drizzle Kit commands work correctly

2. **Created `db-migrate` skill** - Enforces the correct workflow:
   - Modify `schema.ts` first
   - Run `pnpm drizzle-kit generate` to create migration
   - Commit both together

3. **Updated `AGENTS.md`** - Added schema change rules referencing the skill

## Refs

Refs #19