### PR TITLE
fix(ui): Sync mobile nav links with main nav

### DIFF
--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -17,9 +17,9 @@ interface MobileNavProps {
 
 const navItems: NavItem[] = [
   { label: 'Overview', href: '/', matchPaths: ['/'] },
-  { label: 'Users', href: '/users', matchPaths: ['/users'] },
+  { label: 'Team', href: '/team', matchPaths: ['/team', '/users', '/adoption'] },
+  { label: 'Usage', href: '/usage', matchPaths: ['/usage'] },
   { label: 'Commits', href: '/commits', matchPaths: ['/commits'] },
-  { label: 'Adoption', href: '/adoption', matchPaths: ['/adoption'] },
   { label: 'Tips', href: '/tips', matchPaths: ['/tips'] },
   { label: 'Status', href: '/status', matchPaths: ['/status'] },
 ];
@@ -71,7 +71,7 @@ export function MobileNav({ days }: MobileNavProps) {
 
   const getHref = (item: NavItem) => {
     // Preserve days param for routes that use it (not tips or status)
-    if (item.href === '/' || item.href === '/users' || item.href === '/commits' || item.href === '/adoption') {
+    if (item.href === '/' || item.href === '/team' || item.href === '/usage' || item.href === '/commits') {
       return `${item.href}?days=${days}`;
     }
     return item.href;


### PR DESCRIPTION
Updated MobileNav to match MainNav navigation items:
- Changed "Users" to "Team" (/team)
- Added "Usage" (/usage)
- Removed separate "Adoption" link (now under Team)
- Updated getHref to preserve days param for correct routes

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>