### PR TITLE
fix: Update link to dashboard in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Track and analyze AI coding tool usage across your team. Supports multiple providers with a modular architecture.
 
-![Abacus Dashboard](docs/screenshot.png)
+![Abacus Dashboard](docs/src/assets/screenshot.png)
 
 ## Features
 


### PR DESCRIPTION
Saw this repository on LinkedIn and thought it was very interesting! I noticed that the screenshot for the README got moved when the docs site was made in #25; this PR should point it back to the right place.