### PR TITLE
feat(users): Add Raw Usage tab to user profile pages

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,6 @@
       "Bash(tail:*)",
       "Bash(cat:*)",
       "Bash(tree:*)",
-
       "Bash(git status:*)",
       "Bash(git log:*)",
       "Bash(git diff:*)",
@@ -24,7 +23,6 @@
       "Bash(git fetch:*)",
       "Bash(git ls-files:*)",
       "Bash(git blame:*)",
-
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr checks:*)",
@@ -36,19 +34,16 @@
       "Bash(gh run logs:*)",
       "Bash(gh repo view:*)",
       "Bash(gh api:*)",
-
       "Bash(node --version:*)",
       "Bash(pnpm list:*)",
       "Bash(pnpm why:*)",
       "Bash(pnpm test:*)",
       "Bash(tsc --version:*)",
-
       "Bash(docker --version:*)",
       "Bash(docker ps:*)",
       "Bash(docker images:*)",
       "Bash(docker-compose ps:*)",
       "Bash(docker-compose config:*)",
-
       "WebFetch(domain:docs.anthropic.com)",
       "WebFetch(domain:docs.sentry.io)",
       "WebFetch(domain:develop.sentry.dev)",
@@ -61,7 +56,6 @@
       "WebFetch(domain:www.better-auth.com)",
       "WebFetch(domain:orm.drizzle.team)",
       "WebFetch(domain:vitest.dev)",
-
       "Skill(sentry-skills:commit)",
       "Skill(sentry-skills:create-pr)",
       "Skill(sentry-skills:code-review)",
@@ -70,7 +64,6 @@
       "Skill(sentry-skills:iterate-pr)",
       "Skill(sentry-skills:claude-settings-audit)",
       "Skill(sentry-skills:agents-md)",
-
       "mcp__sentry__whoami",
       "mcp__sentry__find_teams",
       "mcp__sentry__find_releases",
@@ -83,5 +76,9 @@
       "mcp__sentry__search_issue_events"
     ],
     "deny": []
+  },
+  "enabledPlugins": {
+    "pr-review-toolkit@claude-plugins-official": true,
+    "sentry-skills@sentry-skills": true
   }
 }

--- a/src/app/api/users/[email]/raw-usage/route.test.ts
+++ b/src/app/api/users/[email]/raw-usage/route.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { insertUsageRecord } from '@/lib/queries';
+import { mockAuthenticated, mockUnauthenticated } from '@/test-utils/auth';
+import { GET } from './route';
+
+async function seedTestData() {
+  // Insert multiple records for testing pagination and filtering
+  await insertUsageRecord({
+    date: '2025-01-01',
+    email: 'user1@example.com',
+    tool: 'claude_code',
+    rawModel: 'claude-sonnet-4-20250514',
+    model: 'sonnet-4',
+    inputTokens: 10000,
+    outputTokens: 5000,
+    cacheWriteTokens: 0,
+    cacheReadTokens: 0,
+    cost: 0.15,
+  });
+
+  await insertUsageRecord({
+    date: '2025-01-02',
+    email: 'user1@example.com',
+    tool: 'cursor',
+    rawModel: 'claude-sonnet-4-20250514',
+    model: 'sonnet-4',
+    inputTokens: 8000,
+    outputTokens: 4000,
+    cacheWriteTokens: 0,
+    cacheReadTokens: 0,
+    cost: 0.12,
+  });
+
+  await insertUsageRecord({
+    date: '2025-01-03',
+    email: 'user1@example.com',
+    tool: 'claude_code',
+    rawModel: 'claude-opus-4-20250514',
+    model: 'opus-4',
+    inputTokens: 20000,
+    outputTokens: 10000,
+    cacheWriteTokens: 0,
+    cacheReadTokens: 0,
+    cost: 0.45,
+  });
+}
+
+describe('GET /api/users/[email]/raw-usage', () => {
+  beforeEach(async () => {
+    await seedTestData();
+  });
+
+  it('returns 401 for unauthenticated requests', async () => {
+    await mockUnauthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 400 when startDate is missing', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain('startDate and endDate are required');
+  });
+
+  it('returns 400 when endDate is missing', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain('startDate and endDate are required');
+  });
+
+  it('returns 400 for invalid startDate format', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=invalid&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain('Invalid startDate format');
+  });
+
+  it('returns 400 for invalid endDate format', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=invalid'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain('Invalid endDate format');
+  });
+
+  it('returns empty results for non-existent user email', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/nonexistent@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'nonexistent@example.com' }) }
+    );
+
+    // Email addresses are returned as-is, so we get empty results not 404
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records).toEqual([]);
+    expect(data.totalCount).toBe(0);
+  });
+
+  it('returns 404 for non-existent username', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/nonexistent/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'nonexistent' }) }
+    );
+
+    // Usernames (without @) are resolved via lookup, returns 404 if not found
+    expect(response.status).toBe(404);
+  });
+
+  it('returns raw usage records for authenticated users', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records).toBeDefined();
+    expect(data.totalCount).toBe(3);
+    expect(data.availableTools).toContain('claude_code');
+    expect(data.availableTools).toContain('cursor');
+    expect(data.availableModels).toContain('sonnet-4');
+    expect(data.availableModels).toContain('opus-4');
+  });
+
+  it('returns records in descending date order', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records[0].date).toBe('2025-01-03');
+    expect(data.records[1].date).toBe('2025-01-02');
+    expect(data.records[2].date).toBe('2025-01-01');
+  });
+
+  it('filters by tool', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&tool=claude_code'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.totalCount).toBe(2);
+    expect(data.records.every((r: { tool: string }) => r.tool === 'claude_code')).toBe(true);
+  });
+
+  it('filters by model', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&model=sonnet-4'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.totalCount).toBe(2);
+    expect(data.records.every((r: { model: string }) => r.model === 'sonnet-4')).toBe(true);
+  });
+
+  it('filters by both tool and model', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&tool=claude_code&model=sonnet-4'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.totalCount).toBe(1);
+    expect(data.records[0].tool).toBe('claude_code');
+    expect(data.records[0].model).toBe('sonnet-4');
+  });
+
+  it('supports pagination', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&page=0&limit=2'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records.length).toBe(2);
+    expect(data.totalCount).toBe(3);
+  });
+
+  it('returns second page correctly', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&page=1&limit=2'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records.length).toBe(1);
+    expect(data.totalCount).toBe(3);
+  });
+
+  it('handles negative page number by treating as 0', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&page=-5'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records.length).toBe(3);
+  });
+
+  it('handles NaN page number by treating as 0', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&page=abc'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.records.length).toBe(3);
+  });
+
+  it('caps limit at 100', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31&limit=500'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    // Should not error, limit is capped internally
+  });
+
+  it('supports URL-encoded email addresses', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1%40example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1%40example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.totalCount).toBe(3);
+  });
+
+  it('returns correct totalTokens calculation', async () => {
+    await mockAuthenticated();
+
+    const response = await GET(
+      new Request('http://localhost/api/users/user1@example.com/raw-usage?startDate=2025-01-01&endDate=2025-01-31'),
+      { params: Promise.resolve({ email: 'user1@example.com' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // First record (Jan 3): 20000 + 10000 = 30000 tokens
+    const jan3Record = data.records.find((r: { date: string }) => r.date === '2025-01-03');
+    expect(jan3Record.totalTokens).toBe(30000);
+  });
+});

--- a/src/app/api/users/[email]/raw-usage/route.ts
+++ b/src/app/api/users/[email]/raw-usage/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
+import { getUserRawUsage, getUserUsageFilters, resolveUserEmail } from '@/lib/queries';
+import { getSession } from '@/lib/auth';
+import { isValidDateString } from '@/lib/utils';
+
+async function handler(
+  request: Request,
+  { params }: { params: Promise<{ email: string }> }
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { email: usernameOrEmail } = await params;
+  const { searchParams } = new URL(request.url);
+  const startDate = searchParams.get('startDate');
+  const endDate = searchParams.get('endDate');
+  const parsedPage = parseInt(searchParams.get('page') || '0', 10);
+  const parsedLimit = parseInt(searchParams.get('limit') || '50', 10);
+  const page = Number.isNaN(parsedPage) ? 0 : Math.max(0, parsedPage);
+  const limit = Number.isNaN(parsedLimit) ? 50 : Math.min(Math.max(1, parsedLimit), 100);
+  const tool = searchParams.get('tool') || undefined;
+  const model = searchParams.get('model') || undefined;
+
+  // Validate required date parameters
+  if (!startDate || !endDate) {
+    return NextResponse.json({ error: 'startDate and endDate are required' }, { status: 400 });
+  }
+  if (!isValidDateString(startDate)) {
+    return NextResponse.json({ error: 'Invalid startDate format. Use YYYY-MM-DD.' }, { status: 400 });
+  }
+  if (!isValidDateString(endDate)) {
+    return NextResponse.json({ error: 'Invalid endDate format. Use YYYY-MM-DD.' }, { status: 400 });
+  }
+
+  const decoded = decodeURIComponent(usernameOrEmail);
+
+  // Resolve username to full email if needed
+  const email = await resolveUserEmail(decoded);
+  if (!email) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  const [rawUsage, filters] = await Promise.all([
+    getUserRawUsage(email, startDate, endDate, page, limit, tool, model),
+    getUserUsageFilters(email, startDate, endDate),
+  ]);
+
+  return NextResponse.json({
+    records: rawUsage.records,
+    totalCount: rawUsage.totalCount,
+    availableTools: filters.tools,
+    availableModels: filters.models,
+  });
+}
+
+export const GET = wrapRouteHandlerWithSentry(handler, {
+  method: 'GET',
+  parameterizedRoute: '/api/users/[email]/raw-usage',
+});

--- a/src/components/RawUsageTable.tsx
+++ b/src/components/RawUsageTable.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { formatTokens, formatCurrency, formatModelName } from '@/lib/utils';
+import { Filter } from 'lucide-react';
+
+function formatWhen(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const isCurrentYear = date.getFullYear() === now.getFullYear();
+
+  if (isCurrentYear) {
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Tool color palette - matches user profile page
+const TOOL_COLORS: Record<string, { bg: string; text: string }> = {
+  claude_code: { bg: 'bg-amber-500', text: 'text-amber-400' },
+  cursor: { bg: 'bg-cyan-500', text: 'text-cyan-400' },
+  windsurf: { bg: 'bg-emerald-500', text: 'text-emerald-400' },
+  github_copilot: { bg: 'bg-sky-500', text: 'text-sky-400' },
+  codex: { bg: 'bg-teal-500', text: 'text-teal-400' },
+  default: { bg: 'bg-rose-500', text: 'text-rose-400' },
+};
+
+function getToolColor(tool: string) {
+  return TOOL_COLORS[tool] || TOOL_COLORS.default;
+}
+
+function formatToolName(tool: string): string {
+  const names: Record<string, string> = {
+    claude_code: 'Claude Code',
+    cursor: 'Cursor',
+    windsurf: 'Windsurf',
+    github_copilot: 'GitHub Copilot',
+    codex: 'Codex',
+  };
+  return names[tool] || tool.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+}
+
+interface RawUsageRecord {
+  id: number;
+  date: string;
+  tool: string;
+  model: string;
+  totalTokens: number;
+  cost: number;
+}
+
+interface RawUsageTableProps {
+  email: string;
+  startDate: string;
+  endDate: string;
+}
+
+const ITEMS_PER_PAGE = 50;
+
+export function RawUsageTable({ email, startDate, endDate }: RawUsageTableProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // State from URL params
+  const toolFilter = searchParams.get('tool') || '';
+  const modelFilter = searchParams.get('model') || '';
+  const page = parseInt(searchParams.get('page') || '0', 10);
+
+  // Data state
+  const [records, setRecords] = useState<RawUsageRecord[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [availableTools, setAvailableTools] = useState<string[]>([]);
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Update URL params
+  const updateFilters = useCallback((updates: { tool?: string; model?: string; page?: number }) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', 'raw');
+
+    if (updates.tool !== undefined) {
+      if (updates.tool) {
+        params.set('tool', updates.tool);
+      } else {
+        params.delete('tool');
+      }
+    }
+    if (updates.model !== undefined) {
+      if (updates.model) {
+        params.set('model', updates.model);
+      } else {
+        params.delete('model');
+      }
+    }
+    if (updates.page !== undefined) {
+      if (updates.page > 0) {
+        params.set('page', updates.page.toString());
+      } else {
+        params.delete('page');
+      }
+    }
+
+    router.push(`?${params.toString()}`, { scroll: false });
+  }, [searchParams, router]);
+
+  // Fetch data
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({
+          startDate,
+          endDate,
+          page: page.toString(),
+          limit: ITEMS_PER_PAGE.toString(),
+        });
+        if (toolFilter) params.set('tool', toolFilter);
+        if (modelFilter) params.set('model', modelFilter);
+
+        const response = await fetch(`/api/users/${encodeURIComponent(email)}/raw-usage?${params}`);
+        if (!response.ok) throw new Error('Failed to fetch');
+
+        const data = await response.json();
+        setRecords(data.records);
+        setTotalCount(data.totalCount);
+        setAvailableTools(data.availableTools);
+        setAvailableModels(data.availableModels);
+      } catch {
+        setRecords([]);
+        setTotalCount(0);
+        setError('Failed to load usage records');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [email, startDate, endDate, page, toolFilter, modelFilter]);
+
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-6 text-center">
+        <p className="font-mono text-sm text-red-400">{error}</p>
+        <button
+          onClick={() => window.location.reload()}
+          className="mt-3 font-mono text-xs text-muted hover:text-white/60 cursor-pointer"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <Filter className="w-3 h-3 text-faint" />
+          <select
+            value={toolFilter}
+            onChange={(e) => updateFilters({ tool: e.target.value, page: 0 })}
+            className="bg-[#0a0a0c] border border-white/10 rounded px-2 py-1 font-mono text-[11px] text-muted focus:outline-none focus:border-white/30 cursor-pointer"
+          >
+            <option value="" className="bg-[#0a0a0c]">All Tools</option>
+            {availableTools.map(tool => (
+              <option key={tool} value={tool} className="bg-[#0a0a0c]">
+                {formatToolName(tool)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <select
+          value={modelFilter}
+          onChange={(e) => updateFilters({ model: e.target.value, page: 0 })}
+          className="bg-[#0a0a0c] border border-white/10 rounded px-2 py-1 font-mono text-[11px] text-muted focus:outline-none focus:border-white/30 cursor-pointer"
+        >
+          <option value="" className="bg-[#0a0a0c]">All Models</option>
+          {availableModels.map(model => (
+            <option key={model} value={model} className="bg-[#0a0a0c]">
+              {formatModelName(model)}
+            </option>
+          ))}
+        </select>
+        <span className="font-mono text-[11px] text-faint ml-auto">
+          {totalCount.toLocaleString()} record{totalCount !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className={`relative ${loading ? 'opacity-50' : ''} transition-opacity`}>
+        {loading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/20 z-10">
+            <div className="w-5 h-5 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
+          </div>
+        )}
+
+        <div className="bg-white/[0.02] rounded-lg border border-white/5 overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-white/5">
+                <th className="px-4 py-3 text-left font-mono text-[11px] uppercase tracking-wider text-muted font-normal">
+                  When
+                </th>
+                <th className="px-4 py-3 text-left font-mono text-[11px] uppercase tracking-wider text-muted font-normal">
+                  Tool
+                </th>
+                <th className="px-4 py-3 text-left font-mono text-[11px] uppercase tracking-wider text-muted font-normal">
+                  Model
+                </th>
+                <th className="px-4 py-3 text-right font-mono text-[11px] uppercase tracking-wider text-muted font-normal">
+                  Tokens
+                </th>
+                <th className="px-4 py-3 text-right font-mono text-[11px] uppercase tracking-wider text-muted font-normal">
+                  Cost
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.length === 0 && !loading ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-muted font-mono text-sm">
+                    No usage records found
+                  </td>
+                </tr>
+              ) : (
+                records.map((record) => {
+                  const toolColor = getToolColor(record.tool);
+                  return (
+                    <tr
+                      key={record.id}
+                      className="border-b border-white/5 last:border-b-0 hover:bg-white/[0.02] transition-colors"
+                    >
+                      <td className="px-4 py-3 font-mono text-sm text-muted">
+                        {formatWhen(record.date)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <div className={`w-2 h-2 rounded-full ${toolColor.bg}`} />
+                          <span className="font-mono text-sm text-white/80">
+                            {formatToolName(record.tool)}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-sm text-white/80">
+                        {formatModelName(record.model)}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-sm text-white/80 text-right">
+                        {formatTokens(record.totalTokens)}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-sm text-white/80 text-right">
+                        {formatCurrency(record.cost)}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-4 py-3 border-t border-white/5">
+          <button
+            onClick={() => updateFilters({ page: Math.max(0, page - 1) })}
+            disabled={page === 0}
+            className="font-mono text-xs text-muted hover:text-white/60 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+          >
+            Previous
+          </button>
+          <span className="font-mono text-xs text-muted">
+            Page {page + 1} of {totalPages}
+          </span>
+          <button
+            onClick={() => updateFilters({ page: Math.min(totalPages - 1, page + 1) })}
+            disabled={page >= totalPages - 1}
+            className="font-mono text-xs text-muted hover:text-white/60 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Add a new tab to user profile pages that displays line-item usage records with filtering and pagination. This provides a detailed breakdown of individual usage entries beyond the aggregated overview stats.

Users can now navigate to any profile and click the "Raw Usage" tab to see:
- Individual usage records sorted by date (newest first)
- Filter by tool (Claude Code, Cursor, etc.) and model
- Paginated results (50 per page)
- Total tokens and cost per record

**Implementation:**
- New `/api/users/[email]/raw-usage` endpoint with pagination and filter support
- `RawUsageTable` component with URL-synced state for filters/pagination
- Tab navigation added to existing user profile page
- Comprehensive test coverage (19 tests)

**Code review fixes included:**
- Page number validation (handles negative values and NaN)
- Error state display in table component