### PR TITLE
feat: Auth bypass for local development

### DIFF
--- a/docs/src/content/docs/getting-started/environment-variables.mdx
+++ b/docs/src/content/docs/getting-started/environment-variables.mdx
@@ -63,6 +63,12 @@ See [GitHub Commits setup](/abacus/providers/github-commits/) for details.
 |----------|-------------|
 | `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN for error tracking |
 
+## Local Development
+
+| Variable | Description |
+|----------|-------------|
+| `AUTH_BYPASS_LOCAL` | Set to `true` to bypass SSO login locally. Returns a mock "Dev User" session. |
+
 <Aside type="tip">
   In Vercel, you can paste multi-line values (like the GitHub private key) directly. The newlines will be preserved.
 </Aside>

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,17 @@
-import { auth } from '@/lib/auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth, isAuthBypassed, mockSession } from '@/lib/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
 
-export const { GET, POST } = toNextJsHandler(auth);
+const { GET: betterAuthGET, POST: betterAuthPOST } = toNextJsHandler(auth);
+
+// Wrap GET to intercept get-session when auth is bypassed
+export async function GET(request: NextRequest) {
+  // When auth is bypassed, return mock session for get-session endpoint
+  if (isAuthBypassed && request.nextUrl.pathname.includes('get-session')) {
+    return NextResponse.json(mockSession);
+  }
+
+  return betterAuthGET(request);
+}
+
+export { betterAuthPOST as POST };

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth, isAuthBypassed, mockSession } from '@/lib/auth';
+import { auth } from '@/lib/auth';
+import { isAuthBypassed, createMockSession } from '@/lib/auth-bypass';
 import { toNextJsHandler } from 'better-auth/next-js';
 
 const { GET: betterAuthGET, POST: betterAuthPOST } = toNextJsHandler(auth);
@@ -8,7 +9,7 @@ const { GET: betterAuthGET, POST: betterAuthPOST } = toNextJsHandler(auth);
 export async function GET(request: NextRequest) {
   // When auth is bypassed, return mock session for get-session endpoint
   if (isAuthBypassed && request.nextUrl.pathname.includes('get-session')) {
-    return NextResponse.json(mockSession);
+    return NextResponse.json(createMockSession());
   }
 
   return betterAuthGET(request);

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,18 +1,3 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import { isAuthBypassed, createMockSession } from '@/lib/auth-bypass';
 import { toNextJsHandler } from 'better-auth/next-js';
-
-const { GET: betterAuthGET, POST: betterAuthPOST } = toNextJsHandler(auth);
-
-// Wrap GET to intercept get-session when auth is bypassed
-export async function GET(request: NextRequest) {
-  // When auth is bypassed, return mock session for get-session endpoint
-  if (isAuthBypassed && request.nextUrl.pathname.includes('get-session')) {
-    return NextResponse.json(createMockSession());
-  }
-
-  return betterAuthGET(request);
-}
-
-export { betterAuthPOST as POST };
+export const { GET, POST } = toNextJsHandler(auth);

--- a/src/app/api/commits/pivot/route.ts
+++ b/src/app/api/commits/pivot/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getRepositoryPivot } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const sortBy = searchParams.get('sortBy') || 'totalCommits';

--- a/src/app/api/commits/trends/route.ts
+++ b/src/app/api/commits/trends/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getDailyCommitStats, getCommitStats, getCommitStatsWithComparison } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/export/commits/route.ts
+++ b/src/app/api/export/commits/route.ts
@@ -1,18 +1,13 @@
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getRepositoryPivot } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { convertToCsv, generateExportFilename } from '@/lib/csv';
 import { DEFAULT_DAYS } from '@/lib/constants';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/export/team/route.ts
+++ b/src/app/api/export/team/route.ts
@@ -1,18 +1,13 @@
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getAllUsersPivot } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { convertToCsv, generateExportFilename } from '@/lib/csv';
 import { DEFAULT_DAYS } from '@/lib/constants';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/export/usage/route.ts
+++ b/src/app/api/export/usage/route.ts
@@ -1,18 +1,13 @@
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getModelTrends, getToolTrends } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { convertToCsv, generateExportFilename } from '@/lib/csv';
 import { DEFAULT_DAYS } from '@/lib/constants';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/mappings/route.ts
+++ b/src/app/api/mappings/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getIdentityMappings, setIdentityMapping, deleteIdentityMapping, getUnmappedToolRecords, getKnownEmails } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 
 async function getHandler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const source = searchParams.get('source') || searchParams.get('tool') || undefined;
@@ -28,10 +26,8 @@ async function getHandler(request: Request) {
 const VALID_SOURCES = ['claude_code', 'cursor', 'github', 'gitlab'];
 
 async function postHandler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const body = await request.json();
   const source = body.source || body.tool;
@@ -57,10 +53,8 @@ async function postHandler(request: Request) {
 }
 
 async function deleteHandler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const body = await request.json();
   const source = body.source || body.tool;

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getModelBreakdown } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate') || undefined;

--- a/src/app/api/models/trends/route.ts
+++ b/src/app/api/models/trends/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getModelTrends, getToolTrends } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { DEFAULT_DAYS } from '@/lib/constants';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/repositories/[...slug]/route.ts
+++ b/src/app/api/repositories/[...slug]/route.ts
@@ -9,17 +9,15 @@ import {
   getRepositoryDailyStats,
   getRepositoryDataRange,
 } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(
   request: Request,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { slug } = await params;
 

--- a/src/app/api/stats/commits/route.ts
+++ b/src/app/api/stats/commits/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getCommitStats, getCommitStatsWithComparison } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/stats/lifetime/route.ts
+++ b/src/app/api/stats/lifetime/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getLifetimeStats } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 
 async function handler() {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const stats = await getLifetimeStats();
   return NextResponse.json(stats);

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getOverallStats, getOverallStatsWithComparison, getUnattributedStats } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate') || undefined;

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -5,7 +5,7 @@ import { getCursorSyncState, getCursorBackfillState } from '@/lib/sync/cursor';
 import { getGitHubBackfillState } from '@/lib/sync/github';
 import { getUnmappedGitHubUsers } from '@/lib/sync/github-mappings';
 import { getUnattributedStats, getLifetimeStats, getUnmappedToolRecords } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { getAnthropicKeys, getCursorKeys } from '@/lib/sync/provider-keys';
 
 type SyncStatus = 'up_to_date' | 'behind' | 'never_synced';
@@ -37,10 +37,8 @@ function getBackfillStatus(oldestDate: string | null, isComplete: boolean): Back
 }
 
 async function handler() {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   // Check which providers are configured
   const anthropicConfigured = getAnthropicKeys().length > 0;

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,16 +1,14 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { runFullSync, getSyncState, syncMappings } from '@/lib/sync';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { getAnthropicKeys, getCursorKeys } from '@/lib/sync/provider-keys';
 
 // Get sync status
 async function getHandler() {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const state = await getSyncState('main');
   return NextResponse.json({
@@ -22,10 +20,8 @@ async function getHandler() {
 
 // Trigger manual sync
 async function postHandler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   let body: { startDate?: string; endDate?: string; includeMappings?: boolean; mappingsOnly?: boolean };
   try {

--- a/src/app/api/trends/route.ts
+++ b/src/app/api/trends/route.ts
@@ -1,16 +1,14 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getDailyUsage, getDataCompleteness } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { applyProjections } from '@/lib/projection';
 import { today } from '@/lib/dateUtils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const startDate = searchParams.get('startDate');

--- a/src/app/api/users/[email]/percentile/route.ts
+++ b/src/app/api/users/[email]/percentile/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getUserPercentile, resolveUserEmail } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(
   request: Request,
   { params }: { params: Promise<{ email: string }> }
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { email: usernameOrEmail } = await params;
   const { searchParams } = new URL(request.url);

--- a/src/app/api/users/[email]/raw-usage/route.ts
+++ b/src/app/api/users/[email]/raw-usage/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getUserRawUsage, getUserUsageFilters, resolveUserEmail } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(
   request: Request,
   { params }: { params: Promise<{ email: string }> }
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { email: usernameOrEmail } = await params;
   const { searchParams } = new URL(request.url);

--- a/src/app/api/users/[email]/route.ts
+++ b/src/app/api/users/[email]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getUserDetails, getUserDetailsExtended, getUserLifetimeStats, getUserCommitStats, resolveUserEmail } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 import { getPreviousPeriodDates } from '@/lib/comparison';
 
@@ -9,10 +9,8 @@ async function handler(
   request: Request,
   { params }: { params: Promise<{ email: string }> }
 ) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { email: usernameOrEmail } = await params;
   const { searchParams } = new URL(request.url);

--- a/src/app/api/users/pivot/route.ts
+++ b/src/app/api/users/pivot/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getAllUsersPivot } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const sortBy = searchParams.get('sortBy') || 'totalTokens';

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from 'next/server';
 import { wrapRouteHandlerWithSentry } from '@sentry/nextjs';
 import { getUserSummaries } from '@/lib/queries';
-import { getSession } from '@/lib/auth';
+import { checkAuth } from '@/lib/auth';
 import { isValidDateString } from '@/lib/utils';
 
 async function handler(request: Request) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const authError = await checkAuth();
+  if (authError) return authError;
 
   const { searchParams } = new URL(request.url);
   const limitParsed = parseInt(searchParams.get('limit') || '50', 10);

--- a/src/app/sign-in/layout.tsx
+++ b/src/app/sign-in/layout.tsx
@@ -1,7 +1,8 @@
 import { redirect } from 'next/navigation';
 
 // Redirect to home if auth is bypassed (local development)
-const isAuthBypassed = process.env.AUTH_BYPASS_LOCAL === 'true';
+const isAuthBypassed =
+  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
 
 export default function SignInLayout({ children }: { children: React.ReactNode }) {
   if (isAuthBypassed) {

--- a/src/app/sign-in/layout.tsx
+++ b/src/app/sign-in/layout.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+// Redirect to home if auth is bypassed (local development)
+const isAuthBypassed = process.env.AUTH_BYPASS_LOCAL === 'true';
+
+export default function SignInLayout({ children }: { children: React.ReactNode }) {
+  if (isAuthBypassed) {
+    redirect('/');
+  }
+
+  return children;
+}

--- a/src/app/sign-in/layout.tsx
+++ b/src/app/sign-in/layout.tsx
@@ -1,8 +1,5 @@
 import { redirect } from 'next/navigation';
-
-// Redirect to home if auth is bypassed (local development)
-const isAuthBypassed =
-  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
+import { isAuthBypassed } from '@/lib/auth-bypass';
 
 export default function SignInLayout({ children }: { children: React.ReactNode }) {
   if (isAuthBypassed) {

--- a/src/lib/auth-bypass.ts
+++ b/src/lib/auth-bypass.ts
@@ -1,0 +1,30 @@
+// Dependency-free auth bypass for local development.
+// Must stay dependency-free so it can be imported from Edge runtime (proxy.ts).
+export const isAuthBypassed =
+  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
+
+// Build a fresh mock session each call so dates are never stale in long-running dev servers.
+export function createMockSession() {
+  const now = new Date();
+  return {
+    session: {
+      id: 'dev-session',
+      userId: 'dev-user',
+      expiresAt: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      createdAt: now,
+      updatedAt: now,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Dev Browser',
+      token: 'dev-token',
+    },
+    user: {
+      id: 'dev-user',
+      email: `dev@${process.env.NEXT_PUBLIC_DOMAIN || 'localhost'}`,
+      name: 'Dev User',
+      image: null,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}

--- a/src/lib/auth-bypass.ts
+++ b/src/lib/auth-bypass.ts
@@ -2,29 +2,3 @@
 // Must stay dependency-free so it can be imported from Edge runtime (proxy.ts).
 export const isAuthBypassed =
   process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
-
-// Build a fresh mock session each call so dates are never stale in long-running dev servers.
-export function createMockSession() {
-  const now = new Date();
-  return {
-    session: {
-      id: 'dev-session',
-      userId: 'dev-user',
-      expiresAt: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-      createdAt: now,
-      updatedAt: now,
-      ipAddress: '127.0.0.1',
-      userAgent: 'Dev Browser',
-      token: 'dev-token',
-    },
-    user: {
-      id: 'dev-user',
-      email: `dev@${process.env.NEXT_PUBLIC_DOMAIN || 'localhost'}`,
-      name: 'Dev User',
-      image: null,
-      emailVerified: true,
-      createdAt: now,
-      updatedAt: now,
-    },
-  };
-}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,8 @@ import { Pool } from '@neondatabase/serverless';
 import { headers } from 'next/headers';
 
 // Auth bypass for local development (set AUTH_BYPASS_LOCAL=true in .env.local)
-export const isAuthBypassed = process.env.AUTH_BYPASS_LOCAL === 'true';
+export const isAuthBypassed =
+  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
 
 // Mock session returned when auth is bypassed
 export const mockSession = {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,32 @@ import { betterAuth } from 'better-auth';
 import { Pool } from '@neondatabase/serverless';
 import { headers } from 'next/headers';
 
+// Auth bypass for local development (set AUTH_BYPASS_LOCAL=true in .env.local)
+export const isAuthBypassed = process.env.AUTH_BYPASS_LOCAL === 'true';
+
+// Mock session returned when auth is bypassed
+export const mockSession = {
+  session: {
+    id: 'dev-session',
+    userId: 'dev-user',
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours from now
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: '127.0.0.1',
+    userAgent: 'Dev Browser',
+    token: 'dev-token',
+  },
+  user: {
+    id: 'dev-user',
+    email: `dev@${process.env.NEXT_PUBLIC_DOMAIN || 'localhost'}`,
+    name: 'Dev User',
+    image: null,
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+};
+
 // Create database pool for better-auth
 const pool = new Pool({
   connectionString: process.env.POSTGRES_URL,
@@ -65,6 +91,9 @@ export const auth = betterAuth({
 
 // Helper to get session in server components
 export async function getSession() {
+  if (isAuthBypassed) {
+    return mockSession;
+  }
   return auth.api.getSession({
     headers: await headers(),
   });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,33 +1,7 @@
 import { betterAuth } from 'better-auth';
 import { Pool } from '@neondatabase/serverless';
 import { headers } from 'next/headers';
-
-// Auth bypass for local development (set AUTH_BYPASS_LOCAL=true in .env.local)
-export const isAuthBypassed =
-  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
-
-// Mock session returned when auth is bypassed
-export const mockSession = {
-  session: {
-    id: 'dev-session',
-    userId: 'dev-user',
-    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours from now
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    ipAddress: '127.0.0.1',
-    userAgent: 'Dev Browser',
-    token: 'dev-token',
-  },
-  user: {
-    id: 'dev-user',
-    email: `dev@${process.env.NEXT_PUBLIC_DOMAIN || 'localhost'}`,
-    name: 'Dev User',
-    image: null,
-    emailVerified: true,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-};
+import { isAuthBypassed, createMockSession } from '@/lib/auth-bypass';
 
 // Create database pool for better-auth
 const pool = new Pool({
@@ -93,7 +67,7 @@ export const auth = betterAuth({
 // Helper to get session in server components
 export async function getSession() {
   if (isAuthBypassed) {
-    return mockSession;
+    return createMockSession();
   }
   return auth.api.getSession({
     headers: await headers(),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,8 @@
 import { betterAuth } from 'better-auth';
 import { Pool } from '@neondatabase/serverless';
 import { headers } from 'next/headers';
-import { isAuthBypassed, createMockSession } from '@/lib/auth-bypass';
+import { NextResponse } from 'next/server';
+import { isAuthBypassed } from '@/lib/auth-bypass';
 
 // Create database pool for better-auth
 const pool = new Pool({
@@ -64,21 +65,28 @@ export const auth = betterAuth({
   },
 });
 
-// Helper to get session in server components
+// Helper to get session in server components.
+// Returns the session object or null if not authenticated.
 export async function getSession() {
-  if (isAuthBypassed) {
-    return createMockSession();
-  }
-  return auth.api.getSession({
-    headers: await headers(),
-  });
+  if (isAuthBypassed) return null;
+  return auth.api.getSession({ headers: await headers() });
 }
 
-// Helper to require session (throws if not authenticated)
-export async function requireSession() {
+// Auth guard for API routes.
+// Returns null when authorized (session exists or auth bypass is active),
+// or a 401 Response when unauthorized.
+export async function checkAuth(): Promise<Response | null> {
+  if (isAuthBypassed) return null;
   const session = await getSession();
-  if (!session) {
-    throw new Error('Unauthorized');
-  }
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return null;
+}
+
+// Helper to require session (throws if not authenticated).
+// When auth bypass is active, returns null since no real session exists.
+export async function requireSession() {
+  if (isAuthBypassed) return null;
+  const session = await getSession();
+  if (!session) throw new Error('Unauthorized');
   return session;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,8 @@ import type { NextRequest } from 'next/server';
 import { getSessionCookie } from 'better-auth/cookies';
 
 // Auth bypass for local development (set AUTH_BYPASS_LOCAL=true in .env.local)
-const isAuthBypassed = process.env.AUTH_BYPASS_LOCAL === 'true';
+const isAuthBypassed =
+  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
 
 /**
  * Next.js 16 Proxy (formerly Middleware)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,9 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getSessionCookie } from 'better-auth/cookies';
 
+// Auth bypass for local development (set AUTH_BYPASS_LOCAL=true in .env.local)
+const isAuthBypassed = process.env.AUTH_BYPASS_LOCAL === 'true';
+
 /**
  * Next.js 16 Proxy (formerly Middleware)
  *
@@ -12,6 +15,11 @@ import { getSessionCookie } from 'better-auth/cookies';
  * @see https://nextjs.org/docs/app/api-reference/file-conventions/proxy
  */
 export function proxy(request: NextRequest) {
+  // Skip all auth checks when bypass is enabled
+  if (isAuthBypassed) {
+    return NextResponse.next();
+  }
+
   const { pathname } = request.nextUrl;
 
   // Public routes that don't require authentication

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getSessionCookie } from 'better-auth/cookies';
-
-// Auth bypass for local development (set AUTH_BYPASS_LOCAL=true in .env.local)
-const isAuthBypassed =
-  process.env.NODE_ENV !== 'production' && process.env.AUTH_BYPASS_LOCAL === 'true';
+import { isAuthBypassed } from '@/lib/auth-bypass';
 
 /**
  * Next.js 16 Proxy (formerly Middleware)

--- a/src/test-utils/auth.ts
+++ b/src/test-utils/auth.ts
@@ -35,13 +35,14 @@ type UserOverrides = Partial<typeof testUser>;
  * Call in beforeEach or at the start of a test.
  */
 export async function mockAuthenticated(overrides?: UserOverrides) {
-  const { getSession, requireSession } = await import('@/lib/auth');
+  const { getSession, requireSession, checkAuth } = await import('@/lib/auth');
   const session = {
     user: { ...testUser, ...overrides },
     session: testSession,
   };
   vi.mocked(getSession).mockResolvedValue(session);
   vi.mocked(requireSession).mockResolvedValue(session);
+  vi.mocked(checkAuth).mockResolvedValue(null);
 }
 
 /**
@@ -49,7 +50,8 @@ export async function mockAuthenticated(overrides?: UserOverrides) {
  * This is the default state - call explicitly for clarity.
  */
 export async function mockUnauthenticated() {
-  const { getSession, requireSession } = await import('@/lib/auth');
+  const { getSession, requireSession, checkAuth } = await import('@/lib/auth');
   vi.mocked(getSession).mockResolvedValue(null);
   vi.mocked(requireSession).mockRejectedValue(new Error('Unauthorized'));
+  vi.mocked(checkAuth).mockResolvedValue(Response.json({ error: 'Unauthorized' }, { status: 401 }));
 }

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -217,6 +217,7 @@ afterAll(async () => {
 vi.mock('@/lib/auth', () => ({
   getSession: vi.fn().mockResolvedValue(null),
   requireSession: vi.fn().mockRejectedValue(new Error('Unauthorized')),
+  checkAuth: vi.fn().mockResolvedValue(Response.json({ error: 'Unauthorized' }, { status: 401 })),
 }));
 
 // =============================================================================


### PR DESCRIPTION
- Adds `AUTH_BYPASS_LOCAL=true` env var to skip SSO login in local dev
- Returns a mock "Dev User" session when bypass is enabled
- Guarded by `NODE_ENV !== 'production'` to prevent accidental use in prod
- Bypass logic consolidated into a single dependency-free module (`src/lib/auth-bypass.ts`) for Edge runtime compatibility

Supersedes #48. Fixes #45.
