### PR TITLE
fix: Normalize dateless model IDs and fix display truncation

### DIFF
--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -96,7 +96,7 @@ export function UserTable({ users, days = DEFAULT_DAYS }: UserTableProps) {
                 </td>
                 <td className="py-2.5 sm:py-3 hidden md:table-cell w-24">
                   <span className="text-xs text-muted truncate block">
-                    {user.favoriteModel.replace('claude-', '').split('-').slice(0, 2).join('-')}
+                    {user.favoriteModel}
                   </span>
                 </td>
               </motion.tr>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -56,6 +56,14 @@ describe('normalizeModelName', () => {
     expect(normalizeModelName('3-5-haiku-20241022')).toBe('haiku-3.5');
   });
 
+  it('normalizes dateless model IDs', () => {
+    expect(normalizeModelName('claude-opus-4-6')).toBe('opus-4.6');
+    expect(normalizeModelName('claude-sonnet-4-5')).toBe('sonnet-4.5');
+    expect(normalizeModelName('claude-haiku-4-5')).toBe('haiku-4.5');
+    expect(normalizeModelName('claude-opus-4')).toBe('opus-4');
+    expect(normalizeModelName('claude-sonnet-4')).toBe('sonnet-4');
+  });
+
   it('returns original for unrecognized patterns', () => {
     expect(normalizeModelName('gpt-4')).toBe('gpt-4');
     expect(normalizeModelName('some-random-model')).toBe('some-random-model');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -163,6 +163,22 @@ export function normalizeModelName(model: string): string {
     }
   }
 
+  // "claude-opus-4-6" or "claude-sonnet-4-5" → "opus-4.6" or "sonnet-4.5" (no date)
+  if (!match) {
+    match = normalized.match(/^claude-([a-z]+)-(\d+)-(\d+)$/);
+    if (match) {
+      normalized = `${match[1]}-${match[2]}.${match[3]}`;
+    }
+  }
+
+  // "claude-opus-4" or "claude-sonnet-4" → "opus-4" or "sonnet-4" (no date)
+  if (!match) {
+    match = normalized.match(/^claude-([a-z]+)-(\d+)$/);
+    if (match) {
+      normalized = `${match[1]}-${match[2]}`;
+    }
+  }
+
   // Handle reversed patterns: "4-sonnet" → "sonnet-4", "4.5-opus" → "opus-4.5"
   if (!match) {
     match = normalized.match(/^(\d+(?:\.\d+)?)-([a-z]+)$/);


### PR DESCRIPTION
`normalizeModelName` did not handle model IDs without date suffixes (e.g. `claude-opus-4-6`), causing them to pass through unchanged. The `UserTable` display code then truncated these to just 2 hyphen-separated segments via `.split('-').slice(0, 2).join('-')`, turning `opus-4-6` into `opus-4`.

Adds regex patterns for dateless `claude-{family}-{major}-{minor}` and `claude-{family}-{major}` formats. Removes the lossy split/slice/join display logic in favor of showing the already-normalized model name directly.