### PR TITLE
chore(deps): Bump flatted to 3.4.4 to clear prototype pollution advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3278,8 +3278,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -8213,10 +8213,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.4
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.4: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
Moves `flatted` from `3.3.3` to `3.4.4`, clearing [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) / CVE-2026-33228 — prototype pollution via `parse()`, affecting `<= 3.4.1` and patched in `3.4.2`.

**No dependent bump needed.** `flatted` reaches us as a dev-only transitive: `eslint` → `file-entry-cache@8.0.0` → `flat-cache@4.0.1` → `flatted`. `flat-cache` declares it as `^3.2.9`, a range that already admits the patched line, so the lockfile was simply holding a stale resolution. Nothing in `package.json` changes and no `pnpm.overrides` entry was added.

**Why the lockfile was edited by hand.** `pnpm update flatted` re-resolves neighbouring ranges as a side effect, and here it wanted to pull `fast-uri` from `3.1.6` up to `3.1.7` — which the Sentry npm security firewall currently rejects:

```
ERR_PNPM_FETCH_403  GET https://sfw.security.sentry.io/npm/fast-uri/-/fast-uri-3.1.7.tgz: Forbidden - 403
  This error happened while installing the dependencies of webpack@5.104.1 at schema-utils@4.3.3 at ajv@8.20.0
```

The block is specific to that one version — `flatted@3.4.4` and `fast-uri@3.1.6` both fetch fine (200) through the same proxy. Rather than fight the resolver or drag in a package the firewall is holding back, I edited the two `flatted` entries directly. That sidesteps the unrelated blocker and keeps this to a four-line diff. Someone may want to look separately at why `fast-uri@3.1.7` is being refused, since it will block the next broad relock too.

**Verification.** `pnpm install --frozen-lockfile` succeeds, confirming the lockfile is internally consistent and that `flat-cache@4.0.1` now links to `flatted@3.4.4` on disk. `pnpm tsc --noEmit --skipLibCheck` is clean and `pnpm test` passes (34 files, 266 tests). `pnpm lint` still runs and still reports its 33 pre-existing errors — unchanged by this, and the reason lint is commented out in CI.

Fixes GHSA-rf6f-7fwh-wjgh