### PR TITLE
chore(deps): Relock ws to 8.21.3 to clear memory exhaustion advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5109,8 +5109,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7020,7 +7020,7 @@ snapshots:
     dependencies:
       '@neondatabase/serverless': 0.9.5
       bufferutil: 4.1.0
-      ws: 8.19.0(bufferutil@4.1.0)
+      ws: 8.21.3(bufferutil@4.1.0)
     transitivePeerDependencies:
       - utf-8-validate
 
@@ -8613,7 +8613,7 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.19.0(bufferutil@4.1.0)
+      ws: 8.21.3(bufferutil@4.1.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@exodus/crypto'
@@ -10408,7 +10408,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
-  ws@8.19.0(bufferutil@4.1.0):
+  ws@8.21.3(bufferutil@4.1.0):
     optionalDependencies:
       bufferutil: 4.1.0
 


### PR DESCRIPTION
Moves `ws` from `8.19.0` to `8.21.3`, clearing [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) / CVE-2026-48779 — memory exhaustion DoS from tiny fragments and data chunks, affecting `>= 8.0.0, < 8.21.0`.

**No dependent bump needed.** `ws` arrives through two paths and both already declare ranges that admit the fix:

- `@vercel/postgres@0.10.0` (runtime, via `drizzle-orm`) — `^8.17.1`
- `jsdom@27.4.0` (dev, the vitest environment) — `^8.18.3`

So this was a stale lockfile resolution. `pnpm update ws` was sufficient; `package.json` is untouched, no override, and the diff is five lines with no incidental churn.

**Verification.** `pnpm install --frozen-lockfile` is clean with no unmet peers. `pnpm tsc --noEmit --skipLibCheck` passes, `pnpm test` passes (34 files, 266 tests) — which exercises the jsdom path directly, since jsdom is the test environment — and `next build` completes.

One note on exposure, since this one is `scope: runtime` rather than dev-only: the `@vercel/postgres` path is the websocket transport for Neon connections. `@vercel/postgres` is itself deprecated upstream (pnpm warns about it on every install, pointing at Neon's native Vercel integration), so it may be worth a separate look at retiring that dependency rather than carrying its transitive surface forward. Out of scope here.

Fixes GHSA-96hv-2xvq-fx4p